### PR TITLE
feat: add endpoints as mcp tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "@makehq/sdk",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
                 "@jest/globals": "^29.7.0",
+                "@modelcontextprotocol/sdk": "^1.17.0",
                 "@types/jest": "^29.5.14",
                 "@types/node": "^22.13.10",
                 "dotenv": "^16.4.7",
@@ -1707,6 +1708,30 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.0.tgz",
+            "integrity": "sha512-qFfbWFA7r1Sd8D697L7GkTd36yqDuTkvz0KfOGkgXR8EUhQn3/EDNIR/qUdQNMT8IjmasBvHWuXeisxtXTQT2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.12.6",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.0.1",
+                "express-rate-limit": "^7.5.0",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.23.8",
+                "zod-to-json-schema": "^3.24.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2497,6 +2522,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2760,6 +2799,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/body-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.0",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.6.3",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.0",
+                "raw-body": "^3.0.0",
+                "type-is": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2863,6 +2923,16 @@
                 "esbuild": ">=0.18"
             }
         },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/cac": {
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2871,6 +2941,37 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -3060,12 +3161,69 @@
                 "node": "^14.18.0 || >=16.10.0"
             }
         },
+        "node_modules/content-disposition": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/cors": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
         },
         "node_modules/create-jest": {
             "version": "29.7.0",
@@ -3171,6 +3329,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3214,10 +3382,32 @@
                 "url": "https://dotenvx.com"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true,
             "license": "MIT"
         },
@@ -3264,6 +3454,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/entities": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -3285,6 +3485,39 @@
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/esbuild": {
@@ -3337,6 +3570,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "2.0.0",
@@ -3618,6 +3858,39 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+            "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/execa": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3666,6 +3939,65 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.0",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -3798,6 +4130,24 @@
                 "node": ">=8"
             }
         },
+        "node_modules/finalhandler": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3863,6 +4213,26 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3915,6 +4285,31 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3923,6 +4318,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -3983,6 +4392,19 @@
                 "node": ">=4"
             }
         },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4007,6 +4429,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4027,6 +4462,33 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/http-errors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/http-errors/node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -4035,6 +4497,19 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/ignore": {
@@ -4123,6 +4598,16 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4198,6 +4683,13 @@
             "engines": {
                 "node": ">=0.12.0"
             }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
@@ -5236,12 +5728,45 @@
             "dev": true,
             "license": "Python-2.0"
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/mdurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -5272,6 +5797,29 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/mimic-fn": {
@@ -5332,6 +5880,16 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/node-fetch": {
             "version": "2.7.0",
@@ -5399,6 +5957,32 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/once": {
@@ -5539,6 +6123,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5600,6 +6194,16 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/path-to-regexp": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5628,6 +6232,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+            "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/pkg-dir": {
@@ -5761,6 +6375,20 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5798,6 +6426,22 @@
             ],
             "license": "MIT"
         },
+        "node_modules/qs": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5818,6 +6462,32 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.6.3",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/react-is": {
             "version": "18.3.1",
@@ -5955,6 +6625,23 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5979,6 +6666,34 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5988,6 +6703,52 @@
             "bin": {
                 "semver": "bin/semver.js"
             }
+        },
+        "node_modules/send": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "mime-types": "^3.0.1",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -6010,6 +6771,82 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/signal-exit": {
@@ -6075,6 +6912,16 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/string-length": {
@@ -6388,6 +7235,16 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6661,6 +7518,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/typedoc": {
             "version": "0.28.0",
             "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.0.tgz",
@@ -6762,6 +7634,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -6823,6 +7705,16 @@
             },
             "engines": {
                 "node": ">=10.12.0"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/walker": {
@@ -7017,6 +7909,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.24.6",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+            "dev": true,
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.24.1"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",
@@ -18,7 +18,8 @@
         "test:integration": "jest --coverage --coverageReporters=\"text\" --runInBand --forceExit --verbose false --testMatch \"**/test/**/*.integration.test.ts\"",
         "publish:jsr": "npx jsr publish --allow-dirty",
         "lint": "tsc && eslint --quiet .",
-        "format": "npx prettier . --write"
+        "format": "npx prettier . --write",
+        "inspector": "npx @modelcontextprotocol/inspector scripts/run-mcp-server.mjs"
     },
     "exports": {
         ".": {
@@ -29,6 +30,16 @@
             "require": {
                 "types": "./dist/index.d.cts",
                 "default": "./dist/index.cjs"
+            }
+        },
+        "./mcp": {
+            "import": {
+                "types": "./dist/mcp.d.ts",
+                "default": "./dist/mcp.js"
+            },
+            "require": {
+                "types": "./dist/mcp.d.cts",
+                "default": "./dist/mcp.cjs"
             }
         }
     },
@@ -41,6 +52,7 @@
     "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@jest/globals": "^29.7.0",
+        "@modelcontextprotocol/sdk": "^1.17.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.10",
         "dotenv": "^16.4.7",

--- a/scripts/run-mcp-server.mjs
+++ b/scripts/run-mcp-server.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import dotenv from 'dotenv';
+dotenv.config({ path: `${import.meta.dirname}/../.env` });
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { Make } from '../dist/index.js';
+import { MakeMCPTools } from '../dist/mcp.js';
+
+const server = new Server(
+    {
+        name: 'Make',
+        version: '0.1.0',
+    },
+    {
+        capabilities: {
+            tools: {},
+        },
+    },
+);
+
+if (!process.env.MAKE_API_KEY) {
+    console.error('Please provide MAKE_API_KEY environment variable.');
+    process.exit(1);
+}
+if (!process.env.MAKE_ZONE) {
+    console.error('Please provide MAKE_ZONE environment variable.');
+    process.exit(1);
+}
+
+const make = new Make(process.env.MAKE_API_KEY, process.env.MAKE_ZONE);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+        tools: MakeMCPTools.map(tool => {
+            return {
+                name: tool.name,
+                title: tool.title,
+                description: tool.description,
+                inputSchema: tool.inputSchema,
+            };
+        }),
+    };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async request => {
+    const tool = MakeMCPTools.find(tool => tool.name === request.params.name);
+    if (!tool) {
+        throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+    return {
+        content: [
+            {
+                type: 'text',
+                text: JSON.stringify(await tool.execute(make, request.params.arguments)),
+            },
+        ],
+    };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/src/endpoints/blueprints.mcp.ts
+++ b/src/endpoints/blueprints.mcp.ts
@@ -1,0 +1,40 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'blueprints_get',
+        title: 'Get scenario blueprint',
+        description: 'Get the blueprint of a scenario',
+        category: 'blueprints',
+        scope: 'scenarios:read',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to get the blueprint for' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.blueprints.get(args.scenarioId);
+        },
+    },
+    {
+        name: 'blueprints_versions',
+        title: 'Get blueprint versions',
+        description: "Get all versions of a scenario's blueprint",
+        category: 'blueprints',
+        scope: 'scenarios:read',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to get blueprint versions for' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.blueprints.versions(args.scenarioId);
+        },
+    },
+];

--- a/src/endpoints/connections.mcp.ts
+++ b/src/endpoints/connections.mcp.ts
@@ -1,0 +1,194 @@
+import type { Make } from '../make.js';
+import type { JSONValue } from '../types.js';
+
+export const tools = [
+    {
+        name: 'connections_list',
+        title: 'List connections',
+        description: 'List connections for a team',
+        category: 'connections',
+        scope: 'connections:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to list connections for' },
+                type: { type: 'array', items: { type: 'string' }, description: 'Filter by connection type' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number; type?: string[] }) => {
+            return await make.connections.list(args.teamId, { type: args.type });
+        },
+    },
+    {
+        name: 'connections_get',
+        title: 'Get connection',
+        description: 'Get details of a specific connection',
+        category: 'connections',
+        scope: 'connections:read',
+        identifier: 'connectionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionId: { type: 'number', description: 'The connection ID to get' },
+            },
+            required: ['connectionId'],
+        },
+        execute: async (make: Make, args: { connectionId: number }) => {
+            return await make.connections.get(args.connectionId);
+        },
+    },
+    {
+        name: 'connections_create',
+        title: 'Create connection',
+        description: 'Create a new connection',
+        category: 'connections',
+        scope: 'connections:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'Connection type name (internal identifier)' },
+                accountName: { type: 'string', description: 'Human-readable name for the connection' },
+                accountType: { type: 'string', description: 'Authentication type (basic, oauth)' },
+                teamId: { type: 'number', description: 'ID of the team to create the connection in' },
+                data: { type: 'object', description: 'Connection configuration data' },
+                scope: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'OAuth scopes',
+                },
+            },
+            required: ['name', 'accountName', 'accountType', 'teamId'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                name: string;
+                accountName: string;
+                accountType: string;
+                teamId: number;
+                data?: Record<string, JSONValue>;
+                scope?: string[];
+            },
+        ) => {
+            return await make.connections.create(args);
+        },
+    },
+    {
+        name: 'connections_update',
+        title: 'Update connection',
+        description: "Update a connection's configuration data",
+        category: 'connections',
+        scope: 'connections:write',
+        identifier: 'connectionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionId: { type: 'number', description: 'The connection ID to update' },
+                data: { type: 'object', description: 'Connection configuration data to update' },
+            },
+            required: ['connectionId', 'data'],
+        },
+        execute: async (make: Make, args: { connectionId: number; data: Record<string, JSONValue> }) => {
+            return await make.connections.update(args.connectionId, args.data);
+        },
+    },
+    {
+        name: 'connections_rename',
+        title: 'Rename connection',
+        description: 'Rename a connection',
+        category: 'connections',
+        scope: 'connections:write',
+        identifier: 'connectionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionId: { type: 'number', description: 'The connection ID to rename' },
+                name: { type: 'string', description: 'The new name for the connection' },
+            },
+            required: ['connectionId', 'name'],
+        },
+        execute: async (make: Make, args: { connectionId: number; name: string }) => {
+            return await make.connections.rename(args.connectionId, args.name);
+        },
+    },
+    {
+        name: 'connections_verify',
+        title: 'Verify connection',
+        description: 'Verify if a connection is working correctly',
+        category: 'connections',
+        scope: 'connections:write',
+        identifier: 'connectionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionId: { type: 'number', description: 'The connection ID to verify' },
+            },
+            required: ['connectionId'],
+        },
+        execute: async (make: Make, args: { connectionId: number }) => {
+            return await make.connections.verify(args.connectionId);
+        },
+    },
+    {
+        name: 'connections_scoped',
+        title: 'Verify connection scopes',
+        description: 'Verify if given OAuth scopes are set for a given connection',
+        category: 'connections',
+        scope: 'connections:write',
+        identifier: 'connectionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionId: { type: 'number', description: 'The connection ID to update scopes for' },
+                scope: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Array of scope identifiers to set',
+                },
+            },
+            required: ['connectionId', 'scope'],
+        },
+        execute: async (make: Make, args: { connectionId: number; scope: string[] }) => {
+            return await make.connections.scoped(args.connectionId, args.scope);
+        },
+    },
+    {
+        name: 'connections_list_editable_parameters',
+        title: 'List editable connection parameters',
+        description: 'List editable parameters for a connection',
+        category: 'connections',
+        scope: 'connections:read',
+        identifier: 'connectionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionId: { type: 'number', description: 'The connection ID to get editable parameters for' },
+            },
+            required: ['connectionId'],
+        },
+        execute: async (make: Make, args: { connectionId: number }) => {
+            return await make.connections.listEditableParameters(args.connectionId);
+        },
+    },
+    {
+        name: 'connections_delete',
+        title: 'Delete connection',
+        description: 'Delete a connection',
+        category: 'connections',
+        scope: 'connections:write',
+        identifier: 'connectionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionId: { type: 'number', description: 'The connection ID to delete' },
+            },
+            required: ['connectionId'],
+        },
+        execute: async (make: Make, args: { connectionId: number }) => {
+            return await make.connections.delete(args.connectionId);
+        },
+    },
+];

--- a/src/endpoints/connections.ts
+++ b/src/endpoints/connections.ts
@@ -315,10 +315,10 @@ export class Connections {
     }
 
     /**
-     * Update the OAuth scopes for a connection.
-     * @param connectionId The connection ID to update scopes for
-     * @param scope Array of scope identifiers to set
-     * @returns Promise with a boolean indicating if the connection is now scoped
+     * Verify if given OAuth scopes are set for a given connection.
+     * @param connectionId The connection ID to validate scopes for
+     * @param scope Array of OAuth scopes to validate
+     * @returns Promise with a boolean indicating if the connection has the given scopes
      */
     async scoped(connectionId: number, scope: string[]): Promise<boolean> {
         return (

--- a/src/endpoints/data-store-records.mcp.ts
+++ b/src/endpoints/data-store-records.mcp.ts
@@ -1,0 +1,107 @@
+import type { Make } from '../make.js';
+import type { JSONValue } from '../types.js';
+
+export const tools = [
+    {
+        name: 'data_store_records_list',
+        title: 'List data store records',
+        description: 'List all records in a data store',
+        category: 'data-store-records',
+        scope: 'datastores:read',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID to list records from' },
+                limit: { type: 'number', description: 'Maximum number of records to return' },
+            },
+            required: ['dataStoreId'],
+        },
+        execute: async (make: Make, args: { dataStoreId: number; limit?: number }) => {
+            return await make.dataStores.records.list(args.dataStoreId, { pg: { limit: args.limit } });
+        },
+    },
+    {
+        name: 'data_store_records_create',
+        title: 'Create data store record',
+        description: 'Create a new record in a data store',
+        category: 'data-store-records',
+        scope: 'datastores:write',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID to create the record in' },
+                key: { type: 'string', description: 'Unique key for the record (optional)' },
+                data: { type: 'object', description: 'Record data' },
+            },
+            required: ['dataStoreId', 'data'],
+        },
+        execute: async (make: Make, args: { dataStoreId: number; data: Record<string, JSONValue>; key?: string }) => {
+            if (args.key) {
+                return await make.dataStores.records.create(args.dataStoreId, args.key, args.data);
+            } else {
+                return await make.dataStores.records.create(args.dataStoreId, args.data);
+            }
+        },
+    },
+    {
+        name: 'data_store_records_update',
+        title: 'Update data store record',
+        description: 'Update an existing record in a data store',
+        category: 'data-store-records',
+        scope: 'datastores:write',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID containing the record' },
+                key: { type: 'string', description: 'Unique key of the record to update' },
+                data: { type: 'object', description: 'Updated record data' },
+            },
+            required: ['dataStoreId', 'key', 'data'],
+        },
+        execute: async (make: Make, args: { dataStoreId: number; key: string; data: Record<string, JSONValue> }) => {
+            return await make.dataStores.records.update(args.dataStoreId, args.key, args.data);
+        },
+    },
+    {
+        name: 'data_store_records_replace',
+        title: 'Replace data store record',
+        description: "Replace an existing record in a data store or create if it doesn't exist",
+        category: 'data-store-records',
+        scope: 'datastores:write',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID containing the record' },
+                key: { type: 'string', description: 'Unique key of the record to replace' },
+                data: { type: 'object', description: 'New record data' },
+            },
+            required: ['dataStoreId', 'key', 'data'],
+        },
+        execute: async (make: Make, args: { dataStoreId: number; key: string; data: Record<string, JSONValue> }) => {
+            return await make.dataStores.records.replace(args.dataStoreId, args.key, args.data);
+        },
+    },
+    {
+        name: 'data_store_records_delete',
+        title: 'Delete data store records',
+        description: 'Delete specific records from a data store by keys',
+        category: 'data-store-records',
+        scope: 'datastores:write',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID to delete records from' },
+                keys: { type: 'array', items: { type: 'string' }, description: 'Array of record keys to delete' },
+            },
+            required: ['dataStoreId', 'keys'],
+        },
+        execute: async (make: Make, args: { dataStoreId: number; keys: string[] }) => {
+            return await make.dataStores.records.delete(args.dataStoreId, args.keys);
+        },
+    },
+];

--- a/src/endpoints/data-store-records.ts
+++ b/src/endpoints/data-store-records.ts
@@ -168,23 +168,4 @@ export class DataStoreRecords {
             },
         });
     }
-
-    /**
-     * Delete all records from a data store, with optional exceptions.
-     * @param dataStoreId The data store ID to clear
-     * @param exceptKeys Optional array of record keys to preserve
-     * @returns Promise that resolves when the records are deleted
-     */
-    async deleteAll(dataStoreId: number, exceptKeys?: string[]): Promise<void> {
-        await this.#fetch(`/data-stores/${dataStoreId}/data`, {
-            method: 'DELETE',
-            query: {
-                confirmed: true,
-            },
-            body: {
-                all: true,
-                exceptKeys,
-            },
-        });
-    }
 }

--- a/src/endpoints/data-stores.mcp.ts
+++ b/src/endpoints/data-stores.mcp.ts
@@ -1,0 +1,110 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'data_stores_list',
+        title: 'List data stores',
+        description: 'List all data stores for a team',
+        category: 'data-stores',
+        scope: 'datastores:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to filter data stores by' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.dataStores.list(args.teamId);
+        },
+    },
+    {
+        name: 'data_stores_get',
+        title: 'Get data store',
+        description: 'Get data store details by ID',
+        category: 'data-stores',
+        scope: 'datastores:read',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID to retrieve' },
+            },
+            required: ['dataStoreId'],
+        },
+        execute: async (make: Make, args: { dataStoreId: number }) => {
+            return await make.dataStores.get(args.dataStoreId);
+        },
+    },
+    {
+        name: 'data_stores_create',
+        title: 'Create data store',
+        description: 'Create a new data store',
+        category: 'data-stores',
+        scope: 'datastores:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'Name of the data store' },
+                teamId: { type: 'number', description: 'ID of the team to create the data store in' },
+                maxSizeMB: { type: 'number', description: 'Maximum size in MB for the data store' },
+                datastructureId: {
+                    type: 'number',
+                    description: 'ID of the data structure defining the record format',
+                },
+            },
+            required: ['name', 'teamId', 'maxSizeMB'],
+        },
+        execute: async (
+            make: Make,
+            args: { name: string; teamId: number; maxSizeMB: number; datastructureId?: number },
+        ) => {
+            return await make.dataStores.create(args);
+        },
+    },
+    {
+        name: 'data_stores_update',
+        title: 'Update data store',
+        description: 'Update a data store',
+        category: 'data-stores',
+        scope: 'datastores:write',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID to update' },
+                name: { type: 'string', description: 'New name for the data store' },
+                maxSizeMB: { type: 'number', description: 'New maximum size in MB for the data store' },
+                datastructureId: { type: 'number', description: 'New data structure ID' },
+            },
+            required: ['dataStoreId'],
+        },
+        execute: async (
+            make: Make,
+            args: { dataStoreId: number; name?: string; maxSizeMB?: number; datastructureId?: number },
+        ) => {
+            const { dataStoreId, ...body } = args;
+            return await make.dataStores.update(dataStoreId, body);
+        },
+    },
+    {
+        name: 'data_stores_delete',
+        title: 'Delete data store',
+        description: 'Delete a data store',
+        category: 'data-stores',
+        scope: 'datastores:write',
+        identifier: 'dataStoreId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStoreId: { type: 'number', description: 'The data store ID to delete' },
+            },
+            required: ['dataStoreId'],
+        },
+        execute: async (make: Make, args: { dataStoreId: number }) => {
+            return await make.dataStores.delete(args.dataStoreId);
+        },
+    },
+];

--- a/src/endpoints/data-stores.ts
+++ b/src/endpoints/data-stores.ts
@@ -88,7 +88,11 @@ type GetDataStoreResponse<C extends keyof DataStore = never> = {
  */
 export type UpdateDataStoreBody = {
     /** New name for the data store */
-    name: string;
+    name?: string;
+    /** Optional ID of a data structure that defines the record format */
+    datastructureId?: number;
+    /** Maximum size limit for the data store in megabytes */
+    maxSizeMB?: number;
 };
 
 /**

--- a/src/endpoints/data-structures.mcp.ts
+++ b/src/endpoints/data-structures.mcp.ts
@@ -1,0 +1,159 @@
+import type { Make } from '../make.js';
+import type { DataStructureField } from './data-structures.js';
+
+export const tools = [
+    {
+        name: 'data_structures_list',
+        title: 'List data structures',
+        description: 'List data structures for a team',
+        category: 'data-structures',
+        scope: 'udts:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to list data structures for' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.dataStructures.list(args.teamId);
+        },
+    },
+    {
+        name: 'data_structures_get',
+        title: 'Get data structure',
+        description: 'Get details of a specific data structure',
+        category: 'data-structures',
+        scope: 'udts:read',
+        identifier: 'dataStructureId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStructureId: { type: 'number', description: 'The data structure ID to retrieve' },
+            },
+            required: ['dataStructureId'],
+        },
+        execute: async (make: Make, args: { dataStructureId: number }) => {
+            return await make.dataStructures.get(args.dataStructureId);
+        },
+    },
+    {
+        name: 'data_structures_create',
+        title: 'Create data structure',
+        description: 'Create a new data structure',
+        category: 'data-structures',
+        scope: 'udts:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: {
+                    type: 'number',
+                    description: 'The unique ID of the team in which the data structure will be created',
+                },
+                name: {
+                    type: 'string',
+                    description: 'The name of the data structure. The maximum length of the name is 128 characters',
+                },
+                strict: {
+                    type: 'boolean',
+                    description: 'Set to true to enforce strict validation of the data put in the data structure',
+                },
+                spec: {
+                    type: 'array',
+                    items: { type: 'object' },
+                    description: 'Sets the data structure specification',
+                },
+            },
+            required: ['teamId', 'name', 'strict', 'spec'],
+        },
+        execute: async (
+            make: Make,
+            args: { teamId: number; name: string; strict: boolean; spec: DataStructureField[] },
+        ) => {
+            return await make.dataStructures.create(args);
+        },
+    },
+    {
+        name: 'data_structures_update',
+        title: 'Update data structure',
+        description: 'Update an existing data structure',
+        category: 'data-structures',
+        scope: 'udts:write',
+        identifier: 'dataStructureId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStructureId: { type: 'number', description: 'The data structure ID to update' },
+                name: {
+                    type: 'string',
+                    description: 'The name of the data structure. The maximum length of the name is 128 characters',
+                },
+                strict: {
+                    type: 'boolean',
+                    description: 'Set to true to enforce strict validation of the data put in the data structure',
+                },
+                spec: {
+                    type: 'array',
+                    items: { type: 'object' },
+                    description: 'Sets the data structure specification',
+                },
+            },
+            required: ['dataStructureId'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                dataStructureId: number;
+                name?: string;
+                strict?: boolean;
+                spec?: DataStructureField[];
+            },
+        ) => {
+            const { dataStructureId, ...body } = args;
+            return await make.dataStructures.update(dataStructureId, body);
+        },
+    },
+    {
+        name: 'data_structures_clone',
+        title: 'Clone data structure',
+        description: 'Clone an existing data structure',
+        category: 'data-structures',
+        scope: 'udts:write',
+        identifier: 'dataStructureId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStructureId: { type: 'number', description: 'The data structure ID to clone' },
+                name: { type: 'string', description: 'Name for the cloned data structure' },
+                targetTeamId: { type: 'number', description: 'Target team ID for the cloned data structure' },
+            },
+            required: ['dataStructureId', 'name', 'targetTeamId'],
+        },
+        execute: async (make: Make, args: { dataStructureId: number; name: string; targetTeamId: number }) => {
+            return await make.dataStructures.clone(args.dataStructureId, {
+                name: args.name,
+                targetTeamId: args.targetTeamId,
+            });
+        },
+    },
+    {
+        name: 'data_structures_delete',
+        title: 'Delete data structure',
+        description: 'Delete a data structure',
+        category: 'data-structures',
+        scope: 'udts:write',
+        identifier: 'dataStructureId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dataStructureId: { type: 'number', description: 'The data structure ID to delete' },
+            },
+            required: ['dataStructureId'],
+        },
+        execute: async (make: Make, args: { dataStructureId: number }) => {
+            return await make.dataStructures.delete(args.dataStructureId);
+        },
+    },
+];

--- a/src/endpoints/enums.mcp.ts
+++ b/src/endpoints/enums.mcp.ts
@@ -1,0 +1,46 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'enums_countries',
+        title: 'List countries',
+        description: 'List all available countries',
+        category: 'enums',
+        scope: undefined,
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+        },
+        execute: async (make: Make) => {
+            return await make.enums.countries();
+        },
+    },
+    {
+        name: 'enums_regions',
+        title: 'List regions',
+        description: 'List all available regions',
+        category: 'enums',
+        scope: undefined,
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+        },
+        execute: async (make: Make) => {
+            return await make.enums.regions();
+        },
+    },
+    {
+        name: 'enums_timezones',
+        title: 'List timezones',
+        description: 'List all available timezones',
+        category: 'enums',
+        scope: undefined,
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+        },
+        execute: async (make: Make) => {
+            return await make.enums.timezones();
+        },
+    },
+];

--- a/src/endpoints/executions.mcp.ts
+++ b/src/endpoints/executions.mcp.ts
@@ -1,0 +1,87 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'executions_list',
+        title: 'List executions',
+        description: 'List executions for a scenario',
+        category: 'executions',
+        scope: 'scenarios:read',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to list executions for' },
+                status: { type: 'string', description: 'Filter by execution status' },
+                from: { type: 'number', description: 'Start timestamp for filtering' },
+                to: { type: 'number', description: 'End timestamp for filtering' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number; status?: number; from?: number; to?: number }) => {
+            const { scenarioId, ...options } = args;
+            return await make.executions.list(scenarioId, options);
+        },
+    },
+    {
+        name: 'executions_get',
+        title: 'Get execution',
+        description: 'Get details of a specific execution',
+        category: 'executions',
+        scope: 'scenarios:read',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID the execution belongs to' },
+                executionId: { type: 'string', description: 'The execution ID to retrieve' },
+            },
+            required: ['scenarioId', 'executionId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number; executionId: string }) => {
+            return await make.executions.get(args.scenarioId, args.executionId);
+        },
+    },
+    {
+        name: 'executions_list_for_incomplete_execution',
+        title: 'List executions for incomplete execution',
+        description: 'List executions for an incomplete execution',
+        category: 'executions',
+        scope: 'dlqs:read',
+        identifier: 'incompleteExecutionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                incompleteExecutionId: {
+                    type: 'string',
+                    description: 'The incomplete execution ID to list executions for',
+                },
+                limit: { type: 'number', description: 'Maximum number of executions to return' },
+            },
+            required: ['incompleteExecutionId'],
+        },
+        execute: async (make: Make, args: { incompleteExecutionId: string; limit?: number }) => {
+            const { incompleteExecutionId } = args;
+            return await make.executions.listForIncompleteExecution(incompleteExecutionId);
+        },
+    },
+    {
+        name: 'executions_get_for_incomplete_execution',
+        title: 'Get execution for incomplete execution',
+        description: 'Get execution details for an incomplete execution',
+        category: 'executions',
+        scope: 'dlqs:read',
+        identifier: 'incompleteExecutionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                incompleteExecutionId: { type: 'string', description: 'The incomplete execution ID' },
+                executionId: { type: 'string', description: 'The execution ID to retrieve' },
+            },
+            required: ['incompleteExecutionId', 'executionId'],
+        },
+        execute: async (make: Make, args: { incompleteExecutionId: string; executionId: string }) => {
+            return await make.executions.getForIncompleteExecution(args.incompleteExecutionId, args.executionId);
+        },
+    },
+];

--- a/src/endpoints/executions.ts
+++ b/src/endpoints/executions.ts
@@ -36,6 +36,12 @@ export type Execution = {
 export type ListExecutionsOptions = {
     /** Pagination options */
     pg?: Partial<Pagination<Execution>>;
+    /** Filter by execution status */
+    status?: number;
+    /** Filter by start timestamp */
+    from?: number;
+    /** Filter by end timestamp */
+    to?: number;
 };
 
 /**

--- a/src/endpoints/folders.mcp.ts
+++ b/src/endpoints/folders.mcp.ts
@@ -63,6 +63,8 @@ export const tools = [
         title: 'Delete folder',
         description: 'Delete a folder',
         category: 'folders',
+        scope: 'scenarios:write',
+        identifier: 'folderId',
         inputSchema: {
             type: 'object',
             properties: {

--- a/src/endpoints/folders.mcp.ts
+++ b/src/endpoints/folders.mcp.ts
@@ -1,0 +1,77 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'folders_list',
+        title: 'List folders',
+        description: 'List folders for a team',
+        category: 'folders',
+        scope: 'scenarios:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to list folders for' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.folders.list(args.teamId);
+        },
+    },
+    {
+        name: 'folders_create',
+        title: 'Create folder',
+        description: 'Create a new folder',
+        category: 'folders',
+        scope: 'scenarios:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID where the folder will be created' },
+                name: { type: 'string', description: 'Name of the folder' },
+            },
+            required: ['teamId', 'name'],
+        },
+        execute: async (make: Make, args: { teamId: number; name: string }) => {
+            return await make.folders.create(args);
+        },
+    },
+    {
+        name: 'folders_update',
+        title: 'Update folder',
+        description: 'Update an existing folder',
+        category: 'folders',
+        scope: 'scenarios:write',
+        identifier: 'folderId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                folderId: { type: 'number', description: 'The folder ID to update' },
+                name: { type: 'string', description: 'New name for the folder' },
+            },
+            required: ['folderId'],
+        },
+        execute: async (make: Make, args: { folderId: number; name?: string }) => {
+            const { folderId, ...body } = args;
+            return await make.folders.update(folderId, body);
+        },
+    },
+    {
+        name: 'folders_delete',
+        title: 'Delete folder',
+        description: 'Delete a folder',
+        category: 'folders',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                folderId: { type: 'number', description: 'The folder ID to delete' },
+            },
+            required: ['folderId'],
+        },
+        execute: async (make: Make, args: { folderId: number }) => {
+            return await make.folders.delete(args.folderId);
+        },
+    },
+];

--- a/src/endpoints/functions.mcp.ts
+++ b/src/endpoints/functions.mcp.ts
@@ -1,0 +1,146 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'functions_list',
+        title: 'List functions',
+        description: 'List custom functions for a team',
+        category: 'functions',
+        scope: 'functions:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to list functions for' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.functions.list(args.teamId);
+        },
+    },
+    {
+        name: 'functions_get',
+        title: 'Get function',
+        description: 'Get details of a specific custom function',
+        category: 'functions',
+        scope: 'functions:read',
+        identifier: 'functionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                functionId: { type: 'number', description: 'The function ID to retrieve' },
+            },
+            required: ['functionId'],
+        },
+        execute: async (make: Make, args: { functionId: number }) => {
+            return await make.functions.get(args.functionId);
+        },
+    },
+    {
+        name: 'functions_create',
+        title: 'Create function',
+        description: 'Create a new custom function',
+        category: 'functions',
+        scope: 'functions:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID where the function will be created' },
+                name: { type: 'string', description: 'The name of the function' },
+                code: { type: 'string', description: 'The function code' },
+                description: { type: 'string', description: 'Description of the function' },
+            },
+            required: ['teamId', 'name', 'code'],
+        },
+        execute: async (make: Make, args: { teamId: number; name: string; code: string; description?: string }) => {
+            const { teamId, ...body } = args;
+            return await make.functions.create(teamId, {
+                ...body,
+                description: body.description || '',
+            });
+        },
+    },
+    {
+        name: 'functions_update',
+        title: 'Update function',
+        description: 'Update an existing custom function',
+        category: 'functions',
+        scope: 'functions:write',
+        identifier: 'functionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                functionId: { type: 'number', description: 'The function ID to update' },
+                name: { type: 'string', description: 'New name for the function' },
+                code: { type: 'string', description: 'Updated function code' },
+                description: { type: 'string', description: 'Updated function description' },
+            },
+            required: ['functionId'],
+        },
+        execute: async (
+            make: Make,
+            args: { functionId: number; name?: string; code?: string; description?: string },
+        ) => {
+            const { functionId, ...body } = args;
+            return await make.functions.update(functionId, body);
+        },
+    },
+    {
+        name: 'functions_delete',
+        title: 'Delete function',
+        description: 'Delete a custom function',
+        category: 'functions',
+        scope: 'functions:write',
+        identifier: 'functionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                functionId: { type: 'number', description: 'The function ID to delete' },
+            },
+            required: ['functionId'],
+        },
+        execute: async (make: Make, args: { functionId: number }) => {
+            return await make.functions.delete(args.functionId);
+        },
+    },
+    {
+        name: 'functions_check',
+        title: 'Check function syntax',
+        description: 'Check the syntax of a function without saving it',
+        category: 'functions',
+        scope: 'functions:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID' },
+                code: { type: 'string', description: 'The function code to check' },
+            },
+            required: ['teamId', 'code'],
+        },
+        execute: async (make: Make, args: { teamId: number; code: string }) => {
+            return await make.functions.check(args.teamId, args.code);
+        },
+    },
+    {
+        name: 'functions_history',
+        title: 'Get function history',
+        description: 'Get the version history of a function',
+        category: 'functions',
+        scope: 'functions:read',
+        identifier: 'functionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                functionId: { type: 'number', description: 'The function ID to get history for' },
+                teamId: { type: 'number', description: 'The team ID the function belongs to' },
+            },
+            required: ['functionId', 'teamId'],
+        },
+        execute: async (make: Make, args: { functionId: number; teamId: number }) => {
+            return await make.functions.history(args.teamId, args.functionId);
+        },
+    },
+];

--- a/src/endpoints/hooks.mcp.ts
+++ b/src/endpoints/hooks.mcp.ts
@@ -1,0 +1,200 @@
+import type { Make } from '../make.js';
+import type { JSONValue } from '../types.js';
+
+export const tools = [
+    {
+        name: 'hooks_list',
+        title: 'List hooks',
+        description: 'List webhooks for a specific team',
+        category: 'hooks',
+        scope: 'hooks:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to list hooks for' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.hooks.list(args.teamId);
+        },
+    },
+    {
+        name: 'hooks_get',
+        title: 'Get hook',
+        description: 'Get details of a specific hook',
+        category: 'hooks',
+        scope: 'hooks:read',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to retrieve' },
+            },
+            required: ['hookId'],
+        },
+        execute: async (make: Make, args: { hookId: number }) => {
+            return await make.hooks.get(args.hookId);
+        },
+    },
+    {
+        name: 'hooks_create',
+        title: 'Create hook',
+        description: 'Create a new webhook',
+        category: 'hooks',
+        scope: 'hooks:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID where the hook will be created' },
+                name: { type: 'string', description: 'The name of the webhook' },
+                typeName: {
+                    type: 'string',
+                    description: 'The hook type related to the app for which it will be created',
+                },
+                data: { type: 'object', description: 'Additional data specific to the hook type' },
+            },
+            required: ['teamId', 'name', 'typeName'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                teamId: number;
+                name: string;
+                typeName: string;
+                data?: Record<string, JSONValue>;
+            },
+        ) => {
+            return await make.hooks.create(args);
+        },
+    },
+    {
+        name: 'hooks_update',
+        title: 'Update hook',
+        description: 'Update an existing webhook',
+        category: 'hooks',
+        scope: 'hooks:write',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to update' },
+                data: { type: 'object', description: 'New data configuration for the hook' },
+            },
+            required: ['hookId', 'data'],
+        },
+        execute: async (make: Make, args: { hookId: number; data: Record<string, JSONValue> }) => {
+            return await make.hooks.update(args.hookId, { data: args.data });
+        },
+    },
+    {
+        name: 'hooks_delete',
+        title: 'Delete hook',
+        description: 'Delete a webhook',
+        category: 'hooks',
+        scope: 'hooks:write',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to delete' },
+            },
+            required: ['hookId'],
+        },
+        execute: async (make: Make, args: { hookId: number }) => {
+            return await make.hooks.delete(args.hookId);
+        },
+    },
+    {
+        name: 'hooks_enable',
+        title: 'Enable hook',
+        description: 'Enable a webhook',
+        category: 'hooks',
+        scope: 'hooks:write',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to enable' },
+            },
+            required: ['hookId'],
+        },
+        execute: async (make: Make, args: { hookId: number }) => {
+            return await make.hooks.enable(args.hookId);
+        },
+    },
+    {
+        name: 'hooks_disable',
+        title: 'Disable hook',
+        description: 'Disable a webhook',
+        category: 'hooks',
+        scope: 'hooks:write',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to disable' },
+            },
+            required: ['hookId'],
+        },
+        execute: async (make: Make, args: { hookId: number }) => {
+            return await make.hooks.disable(args.hookId);
+        },
+    },
+    {
+        name: 'hooks_ping',
+        title: 'Ping hook',
+        description: 'Send a test ping to a webhook',
+        category: 'hooks',
+        scope: 'hooks:read',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to ping' },
+            },
+            required: ['hookId'],
+        },
+        execute: async (make: Make, args: { hookId: number }) => {
+            return await make.hooks.ping(args.hookId);
+        },
+    },
+    {
+        name: 'hooks_learn_start',
+        title: 'Start hook learning',
+        description: 'Start learning mode for a webhook',
+        category: 'hooks',
+        scope: 'hooks:write',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to start learning for' },
+            },
+            required: ['hookId'],
+        },
+        execute: async (make: Make, args: { hookId: number }) => {
+            return await make.hooks.learnStart(args.hookId);
+        },
+    },
+    {
+        name: 'hooks_learn_stop',
+        title: 'Stop hook learning',
+        description: 'Stop learning mode for a webhook',
+        category: 'hooks',
+        scope: 'hooks:write',
+        identifier: 'hookId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                hookId: { type: 'number', description: 'The hook ID to stop learning for' },
+            },
+            required: ['hookId'],
+        },
+        execute: async (make: Make, args: { hookId: number }) => {
+            return await make.hooks.learnStop(args.hookId);
+        },
+    },
+];

--- a/src/endpoints/incomplete-executions.mcp.ts
+++ b/src/endpoints/incomplete-executions.mcp.ts
@@ -1,0 +1,40 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'incomplete_executions_list',
+        title: 'List incomplete executions',
+        description: 'List all incomplete executions',
+        category: 'incomplete-executions',
+        scope: 'dlqs:read',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to list incomplete executions for' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.incompleteExecutions.list(args.scenarioId);
+        },
+    },
+    {
+        name: 'incomplete_executions_get',
+        title: 'Get incomplete execution',
+        description: 'Get details of a specific incomplete execution',
+        category: 'incomplete-executions',
+        scope: 'dlqs:read',
+        identifier: 'incompleteExecutionId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                incompleteExecutionId: { type: 'string', description: 'The incomplete execution ID to retrieve' },
+            },
+            required: ['incompleteExecutionId'],
+        },
+        execute: async (make: Make, args: { incompleteExecutionId: string }) => {
+            return await make.incompleteExecutions.get(args.incompleteExecutionId);
+        },
+    },
+];

--- a/src/endpoints/incomplete-executions.ts
+++ b/src/endpoints/incomplete-executions.ts
@@ -130,11 +130,18 @@ export class IncompleteExecutions {
     }
 
     /**
-     * List all incomplete executions.
+     * List all incomplete executions for a scenario.
+     * @param scenarioId The scenario ID to list incomplete executions for
      * @returns Promise with the list of incomplete executions
      */
-    async list(): Promise<IncompleteExecution[]> {
-        return (await this.#fetch<ListIncompleteExecutionsResponse>('/dlqs')).dlqs;
+    async list(scenarioId: number): Promise<IncompleteExecution[]> {
+        return (
+            await this.#fetch<ListIncompleteExecutionsResponse>('/dlqs', {
+                query: {
+                    scenarioId,
+                },
+            })
+        ).dlqs;
     }
 
     /**

--- a/src/endpoints/keys.mcp.ts
+++ b/src/endpoints/keys.mcp.ts
@@ -1,0 +1,104 @@
+import type { Make } from '../make.js';
+import type { JSONValue } from '../types.js';
+
+export const tools = [
+    {
+        name: 'keys_list',
+        title: 'List keys',
+        description: 'List all keys for a team',
+        category: 'keys',
+        scope: 'keys:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to list keys for' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.keys.list(args.teamId);
+        },
+    },
+    {
+        name: 'keys_get',
+        title: 'Get key',
+        description: 'Get details of a specific key',
+        category: 'keys',
+        scope: 'keys:read',
+        identifier: 'keyId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                keyId: { type: 'number', description: 'The key ID to retrieve' },
+            },
+            required: ['keyId'],
+        },
+        execute: async (make: Make, args: { keyId: number }) => {
+            return await make.keys.get(args.keyId);
+        },
+    },
+    {
+        name: 'keys_create',
+        title: 'Create key',
+        description: 'Create a new key',
+        category: 'keys',
+        scope: 'keys:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID where the key will be created' },
+                name: { type: 'string', description: 'Name of the key' },
+                typeName: { type: 'string', description: 'Type of the key' },
+                parameters: { type: 'object', description: 'Key-specific configuration parameters' },
+            },
+            required: ['teamId', 'name', 'typeName', 'parameters'],
+        },
+        execute: async (
+            make: Make,
+            args: { teamId: number; name: string; typeName: string; parameters: Record<string, JSONValue> },
+        ) => {
+            return await make.keys.create(args);
+        },
+    },
+    {
+        name: 'keys_update',
+        title: 'Update key',
+        description: 'Update an existing key',
+        category: 'keys',
+        scope: 'keys:write',
+        identifier: 'keyId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                keyId: { type: 'number', description: 'The key ID to update' },
+                name: { type: 'string', description: 'New name for the key' },
+                parameters: { type: 'object', description: 'Updated key-specific configuration parameters' },
+            },
+            required: ['keyId'],
+        },
+        execute: async (make: Make, args: { keyId: number; name?: string; parameters?: Record<string, JSONValue> }) => {
+            const { keyId, ...body } = args;
+            return await make.keys.update(keyId, body);
+        },
+    },
+    {
+        name: 'keys_delete',
+        title: 'Delete key',
+        description: 'Delete a key',
+        category: 'keys',
+        scope: 'keys:write',
+        identifier: 'keyId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                keyId: { type: 'number', description: 'The key ID to delete' },
+            },
+            required: ['keyId'],
+        },
+        execute: async (make: Make, args: { keyId: number }) => {
+            return await make.keys.delete(args.keyId);
+        },
+    },
+];

--- a/src/endpoints/organizations.mcp.ts
+++ b/src/endpoints/organizations.mcp.ts
@@ -1,0 +1,108 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'organizations_list',
+        title: 'List organizations',
+        description: 'List organizations for the current user',
+        category: 'organizations',
+        scope: 'organizations:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+        },
+        execute: async (make: Make) => {
+            return await make.organizations.list();
+        },
+    },
+    {
+        name: 'organizations_get',
+        title: 'Get organization',
+        description: 'Get details of a specific organization',
+        category: 'organizations',
+        scope: 'organizations:read',
+        identifier: 'organizationId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                organizationId: { type: 'number', description: 'The organization ID to retrieve' },
+            },
+            required: ['organizationId'],
+        },
+        execute: async (make: Make, args: { organizationId: number }) => {
+            return await make.organizations.get(args.organizationId);
+        },
+    },
+    {
+        name: 'organizations_create',
+        title: 'Create organization',
+        description: 'Create a new organization',
+        category: 'organizations',
+        scope: 'organizations:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'Name of the organization' },
+                regionId: { type: 'number', description: 'The ID of the region the organization will be created in' },
+                timezoneId: { type: 'number', description: 'The ID of the timezone' },
+                countryId: { type: 'number', description: 'The ID of the country' },
+            },
+            required: ['name', 'regionId', 'timezoneId', 'countryId'],
+        },
+        execute: async (
+            make: Make,
+            args: { name: string; regionId: number; timezoneId: number; countryId: number },
+        ) => {
+            return await make.organizations.create(args);
+        },
+    },
+    {
+        name: 'organizations_update',
+        title: 'Update organization',
+        description: 'Update an existing organization',
+        category: 'organizations',
+        scope: 'organizations:write',
+        identifier: 'organizationId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                organizationId: { type: 'number', description: 'The organization ID to update' },
+                name: { type: 'string', description: 'New name for the organization' },
+                countryId: { type: 'number', description: 'New country ID' },
+                timezoneId: { type: 'number', description: 'New timezone ID' },
+            },
+            required: ['organizationId'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                organizationId: number;
+                name?: string;
+                countryId?: number;
+                timezoneId?: number;
+            },
+        ) => {
+            const { organizationId, ...body } = args;
+            return await make.organizations.update(organizationId, body);
+        },
+    },
+    {
+        name: 'organizations_delete',
+        title: 'Delete organization',
+        description: 'Delete an organization',
+        category: 'organizations',
+        scope: 'organizations:write',
+        identifier: 'organizationId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                organizationId: { type: 'number', description: 'The organization ID to delete' },
+            },
+            required: ['organizationId'],
+        },
+        execute: async (make: Make, args: { organizationId: number }) => {
+            return await make.organizations.delete(args.organizationId);
+        },
+    },
+];

--- a/src/endpoints/scenarios.mcp.ts
+++ b/src/endpoints/scenarios.mcp.ts
@@ -1,0 +1,282 @@
+import type { Blueprint, DataStructureField } from '../index.js';
+import type { Make } from '../make.js';
+import type { JSONValue } from '../types.js';
+import type { Scheduling } from './scenarios.js';
+
+export const tools = [
+    {
+        name: 'scenarios_list',
+        title: 'List scenarios',
+        description: 'List all scenarios for a team',
+        category: 'scenarios',
+        scope: 'scenarios:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to filter scenarios by' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.scenarios.list(args.teamId);
+        },
+    },
+    {
+        name: 'scenarios_list_in_organization',
+        title: 'List scenarios in organization',
+        description: 'List all scenarios for an organization',
+        category: 'scenarios',
+        scope: 'scenarios:read',
+        identifier: 'organizationId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                organizationId: { type: 'number', description: 'The organization ID to filter scenarios by' },
+            },
+            required: ['organizationId'],
+        },
+        execute: async (make: Make, args: { organizationId: number }) => {
+            return await make.scenarios.listInOrganization(args.organizationId);
+        },
+    },
+    {
+        name: 'scenarios_get',
+        title: 'Get scenario',
+        description: 'Get a scenario by ID',
+        category: 'scenarios',
+        scope: 'scenarios:read',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to retrieve' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.scenarios.get(args.scenarioId);
+        },
+    },
+    {
+        name: 'scenarios_create',
+        title: 'Create scenario',
+        description: 'Create a new scenario',
+        category: 'scenarios',
+        scope: 'scenarios:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'ID of the team where the scenario will be created' },
+                folderId: { type: 'number', description: 'ID of the folder where the scenario will be placed' },
+                scheduling: { description: 'Scheduling configuration for the scenario' },
+                blueprint: { description: 'Blueprint containing the scenario configuration' },
+                basedon: { type: 'string', description: 'ID of an existing template to base this one on' },
+                confirmed: {
+                    type: 'boolean',
+                    description: 'Confirmation in case the scenario uses apps that are not yet installed',
+                },
+            },
+            required: ['teamId', 'scheduling', 'blueprint'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                teamId: number;
+                folderId?: number;
+                scheduling: Scheduling;
+                blueprint: Blueprint;
+                basedon?: string;
+                cols?: string[];
+                confirmed?: boolean;
+            },
+        ) => {
+            const { confirmed, ...body } = args;
+            return await make.scenarios.create(body, { confirmed });
+        },
+    },
+    {
+        name: 'scenarios_update',
+        title: 'Update scenario',
+        description: 'Update a scenario',
+        category: 'scenarios',
+        scope: 'scenarios:write',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to update' },
+                name: { type: 'string', description: 'New name for the scenario' },
+                description: { type: 'string', description: 'New description for the scenario' },
+                folderId: { type: 'number', description: 'New folder ID for the scenario' },
+                scheduling: { description: 'Updated scheduling configuration' },
+                blueprint: { description: 'Updated blueprint configuration' },
+                confirmed: {
+                    type: 'boolean',
+                    description: 'Confirmation in case the scenario uses apps that are not yet installed',
+                },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                scenarioId: number;
+                name?: string;
+                description?: string;
+                folderId?: number;
+                scheduling?: Scheduling;
+                blueprint?: Blueprint;
+                cols?: string[];
+                confirmed?: boolean;
+            },
+        ) => {
+            const { scenarioId, confirmed, ...body } = args;
+            return await make.scenarios.update(scenarioId, body, { confirmed });
+        },
+    },
+    {
+        name: 'scenarios_delete',
+        title: 'Delete scenario',
+        description: 'Delete a scenario',
+        category: 'scenarios',
+        scope: 'scenarios:write',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to delete' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.scenarios.delete(args.scenarioId);
+        },
+    },
+    {
+        name: 'scenarios_activate',
+        title: 'Activate scenario',
+        description: 'Activate a scenario',
+        category: 'scenarios',
+        scope: 'scenarios:write',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to activate' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.scenarios.activate(args.scenarioId);
+        },
+    },
+    {
+        name: 'scenarios_deactivate',
+        title: 'Deactivate scenario',
+        description: 'Deactivate a scenario',
+        category: 'scenarios',
+        scope: 'scenarios:write',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to deactivate' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.scenarios.deactivate(args.scenarioId);
+        },
+    },
+    {
+        name: 'scenarios_run',
+        title: 'Run scenario',
+        description: 'Execute a scenario with optional input data',
+        category: 'scenarios',
+        scope: 'scenarios:write',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to run' },
+                data: { type: 'object', description: 'Optional input data for the scenario' },
+                responsive: { type: 'boolean', description: 'Whether to run responsively' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (
+            make: Make,
+            args: { scenarioId: number; data?: Record<string, JSONValue>; responsive?: boolean },
+        ) => {
+            const { scenarioId, data, responsive } = args;
+            return await make.scenarios.run(scenarioId, data, { responsive });
+        },
+    },
+    {
+        name: 'scenarios_interface',
+        title: 'Get scenario interface',
+        description: 'Get the interface for a scenario',
+        category: 'scenarios',
+        scope: 'scenarios:read',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to get the interface for' },
+            },
+            required: ['scenarioId'],
+        },
+        execute: async (make: Make, args: { scenarioId: number }) => {
+            return await make.scenarios.getInterface(args.scenarioId);
+        },
+    },
+    {
+        name: 'scenarios_set_interface',
+        title: 'Set scenario interface',
+        description: 'Update the interface for a scenario',
+        category: 'scenarios',
+        scope: 'scenarios:write',
+        identifier: 'scenarioId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                scenarioId: { type: 'number', description: 'The scenario ID to update the interface for' },
+                interface: {
+                    type: 'object',
+                    description: 'The interface definition with input and output specifications',
+                    properties: {
+                        input: {
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                            },
+                            description: 'Input fields for the scenario',
+                        },
+                        output: {
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                            },
+                            description: 'Output fields for the scenario',
+                        },
+                    },
+                },
+            },
+            required: ['scenarioId', 'interface'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                scenarioId: number;
+                interface: {
+                    input: DataStructureField[];
+                    output: DataStructureField[];
+                };
+            },
+        ) => {
+            return await make.scenarios.setInterface(args.scenarioId, { interface: args.interface });
+        },
+    },
+];

--- a/src/endpoints/scenarios.ts
+++ b/src/endpoints/scenarios.ts
@@ -140,6 +140,22 @@ type GetScenarioInterfaceResponse = {
 };
 
 /**
+ * Parameters for updating a scenario interface.
+ */
+export type UpdateScenarioInterfaceBody = {
+    /** The interface definition with input and output specifications */
+    interface: ScenarioInteface;
+};
+
+/**
+ * Response format for updating a scenario interface.
+ */
+type UpdateScenarioInterfaceResponse = {
+    /** The updated scenario interface definition */
+    interface: ScenarioInteface;
+};
+
+/**
  * Response format for running a scenario.
  */
 export type RunScenarioResponse = {
@@ -216,7 +232,7 @@ export type UpdateScenarioBody = {
 export type UpdateScenarioOptions<C extends keyof Scenario = never> = {
     /** Specific columns/fields to include in the response */
     cols?: C[];
-    /** Whether to confirm the update even if there are warnings */
+    /** Confirmation in case the scenario uses apps that are not yet installed in the organization */
     confirmed?: boolean;
 };
 
@@ -441,8 +457,33 @@ export class Scenarios {
      * Get the interface for a scenario.
      * @param scenarioId The scenario ID to get the interface for
      * @returns Promise with the scenario interface
+     * @deprecated Use getInterface instead
      */
     async ['interface'](scenarioId: number): Promise<ScenarioInteface> {
+        return await this.getInterface(scenarioId);
+    }
+
+    /**
+     * Get the interface for a scenario.
+     * @param scenarioId The scenario ID to get the interface for
+     * @returns Promise with the scenario interface
+     */
+    async getInterface(scenarioId: number): Promise<ScenarioInteface> {
         return (await this.#fetch<GetScenarioInterfaceResponse>(`/scenarios/${scenarioId}/interface`)).interface;
+    }
+
+    /**
+     * Update a scenario interface.
+     * @param scenarioId The scenario ID to update the interface for
+     * @param body The new interface definition
+     * @returns Promise with the updated scenario interface
+     */
+    async setInterface(scenarioId: number, body: UpdateScenarioInterfaceBody): Promise<ScenarioInteface> {
+        return (
+            await this.#fetch<UpdateScenarioInterfaceResponse>(`/scenarios/${scenarioId}/interface`, {
+                method: 'PATCH',
+                body: body,
+            })
+        ).interface;
     }
 }

--- a/src/endpoints/sdk/apps.mcp.ts
+++ b/src/endpoints/sdk/apps.mcp.ts
@@ -1,0 +1,278 @@
+import type { Make } from '../../make.js';
+import type { JSONValue } from '../../types.js';
+
+export const tools = [
+    {
+        name: 'sdk_apps_list',
+        title: 'List SDK apps',
+        description: 'List SDK apps with optional filtering',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+        },
+        execute: async (make: Make) => {
+            return await make.sdk.apps.list();
+        },
+    },
+    {
+        name: 'sdk_apps_get',
+        title: 'Get SDK app',
+        description: 'Get a SDK app by name and version',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+            },
+            required: ['name', 'version'],
+        },
+        execute: async (make: Make, args: { name: string; version: number }) => {
+            return await make.sdk.apps.get(args.name, args.version);
+        },
+    },
+    {
+        name: 'sdk_apps_create',
+        title: 'Create SDK app',
+        description: 'Create a new SDK app',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app visible in the URL' },
+                label: { type: 'string', description: 'The label of the app visible in the scenario builder' },
+                description: { type: 'string', description: 'The description of the app' },
+                theme: { type: 'string', description: 'The color of the app logo' },
+                language: { type: 'string', description: 'The language of the app' },
+                countries: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Countries where the app is available',
+                },
+                private: { type: 'boolean', description: 'Whether the app is private' },
+                audience: { type: 'string', description: 'Audience setting for the app' },
+            },
+            required: ['name', 'label', 'audience'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                name: string;
+                label: string;
+                description?: string;
+                theme?: string;
+                language?: string;
+                countries?: string[];
+                private?: boolean;
+                audience: string;
+            },
+        ) => {
+            return await make.sdk.apps.create(args);
+        },
+    },
+    {
+        name: 'sdk_apps_update',
+        title: 'Update SDK app',
+        description: 'Update an existing SDK app',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+                label: { type: 'string', description: 'The label of the app visible in the scenario builder' },
+                description: { type: 'string', description: 'The description of the app' },
+                theme: { type: 'string', description: 'The color of the app logo' },
+                language: { type: 'string', description: 'The language of the app' },
+                countries: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Countries where the app is available',
+                },
+                audience: { type: 'string', description: 'Audience setting' },
+            },
+            required: ['name', 'version'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                name: string;
+                version: number;
+                label?: string;
+                description?: string;
+                theme?: string;
+                language?: string;
+                countries?: string[];
+                audience?: string;
+            },
+        ) => {
+            const { name, version, ...body } = args;
+            return await make.sdk.apps.update(name, version, body);
+        },
+    },
+    {
+        name: 'sdk_apps_delete',
+        title: 'Delete SDK app',
+        description: 'Delete a SDK app by name and version',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+            },
+            required: ['name', 'version'],
+        },
+        execute: async (make: Make, args: { name: string; version: number }) => {
+            return await make.sdk.apps.delete(args.name, args.version);
+        },
+    },
+    {
+        name: 'sdk_apps_get_section',
+        title: 'Get SDK app section',
+        description: 'Get a specific section of a SDK app',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+                section: {
+                    type: 'string',
+                    enum: ['base', 'groups', 'install', 'installSpec'],
+                    description: 'The section to get',
+                },
+            },
+            required: ['name', 'version', 'section'],
+        },
+        execute: async (
+            make: Make,
+            args: { name: string; version: number; section: 'base' | 'groups' | 'install' | 'installSpec' },
+        ) => {
+            return await make.sdk.apps.getSection(args.name, args.version, args.section);
+        },
+    },
+    {
+        name: 'sdk_apps_set_section',
+        title: 'Set SDK app section',
+        description: 'Set/update a specific section of a SDK app',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+                section: {
+                    type: 'string',
+                    enum: ['base', 'groups', 'install', 'installSpec'],
+                    description: 'The section to set',
+                },
+                body: { type: 'object', description: 'The section data to set' },
+            },
+            required: ['name', 'version', 'section', 'body'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                name: string;
+                version: number;
+                section: 'base' | 'groups' | 'install' | 'installSpec';
+                body: Record<string, JSONValue>;
+            },
+        ) => {
+            return await make.sdk.apps.setSection(args.name, args.version, args.section, args.body);
+        },
+    },
+    {
+        name: 'sdk_apps_get_docs',
+        title: 'Get SDK app documentation',
+        description: 'Get app documentation (readme)',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+            },
+            required: ['name', 'version'],
+        },
+        execute: async (make: Make, args: { name: string; version: number }) => {
+            return await make.sdk.apps.getDocs(args.name, args.version);
+        },
+    },
+    {
+        name: 'sdk_apps_set_docs',
+        title: 'Set SDK app documentation',
+        description: 'Set app documentation (readme)',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+                docs: { type: 'string', description: 'The documentation content in markdown format' },
+            },
+            required: ['name', 'version', 'docs'],
+        },
+        execute: async (make: Make, args: { name: string; version: number; docs: string }) => {
+            return await make.sdk.apps.setDocs(args.name, args.version, args.docs);
+        },
+    },
+    {
+        name: 'sdk_apps_get_common',
+        title: 'Get SDK app common data',
+        description: 'Get app common data (client credentials and shared configuration)',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+            },
+            required: ['name', 'version'],
+        },
+        execute: async (make: Make, args: { name: string; version: number }) => {
+            return await make.sdk.apps.getCommon(args.name, args.version);
+        },
+    },
+    {
+        name: 'sdk_apps_set_common',
+        title: 'Set SDK app common data',
+        description: 'Set app common data (client credentials and shared configuration)',
+        category: 'sdk.apps',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'The name of the app' },
+                version: { type: 'number', description: 'The version of the app' },
+                common: { type: 'object', description: 'The common data to set' },
+            },
+            required: ['name', 'version', 'common'],
+        },
+        execute: async (make: Make, args: { name: string; version: number; common: Record<string, JSONValue> }) => {
+            return await make.sdk.apps.setCommon(args.name, args.version, args.common);
+        },
+    },
+];

--- a/src/endpoints/sdk/connections.mcp.ts
+++ b/src/endpoints/sdk/connections.mcp.ts
@@ -1,0 +1,197 @@
+import type { Make } from '../../make.js';
+import type { JSONValue } from '../../types.js';
+
+export const tools = [
+    {
+        name: 'sdk_connections_list',
+        title: 'List SDK connections',
+        description: 'List connections for a specific app',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+            },
+            required: ['appName'],
+        },
+        execute: async (make: Make, args: { appName: string }) => {
+            return await make.sdk.connections.list(args.appName);
+        },
+    },
+    {
+        name: 'sdk_connections_get',
+        title: 'Get SDK connection',
+        description: 'Get a single connection by name',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionName: { type: 'string', description: 'The name of the connection' },
+            },
+            required: ['connectionName'],
+        },
+        execute: async (make: Make, args: { connectionName: string }) => {
+            return await make.sdk.connections.get(args.connectionName);
+        },
+    },
+    {
+        name: 'sdk_connections_create',
+        title: 'Create SDK connection',
+        description: 'Create a new connection for a specific app',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                type: { type: 'string', description: 'The type of the connection' },
+                label: { type: 'string', description: 'The label of the connection visible in the scenario builder' },
+            },
+            required: ['appName', 'type', 'label'],
+        },
+        execute: async (make: Make, args: { appName: string; type: string; label: string }) => {
+            const { appName, ...body } = args;
+            return await make.sdk.connections.create(appName, body);
+        },
+    },
+    {
+        name: 'sdk_connections_update',
+        title: 'Update SDK connection',
+        description: 'Update an existing connection',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionName: { type: 'string', description: 'The name of the connection' },
+                label: { type: 'string', description: 'The label of the connection visible in the scenario builder' },
+            },
+            required: ['connectionName'],
+        },
+        execute: async (make: Make, args: { connectionName: string; label?: string }) => {
+            const { connectionName, ...body } = args;
+            return await make.sdk.connections.update(connectionName, body);
+        },
+    },
+    {
+        name: 'sdk_connections_delete',
+        title: 'Delete SDK connection',
+        description: 'Delete a connection',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionName: { type: 'string', description: 'The name of the connection' },
+            },
+            required: ['connectionName'],
+        },
+        execute: async (make: Make, args: { connectionName: string }) => {
+            return await make.sdk.connections.delete(args.connectionName);
+        },
+    },
+    {
+        name: 'sdk_connections_get_section',
+        title: 'Get SDK connection section',
+        description: 'Get a specific section of a connection',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionName: { type: 'string', description: 'The name of the connection' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'parameters', 'scopes', 'scope', 'install', 'installSpec'],
+                    description: 'The section to get',
+                },
+            },
+            required: ['connectionName', 'section'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                connectionName: string;
+                section: 'api' | 'parameters' | 'scopes' | 'scope' | 'install' | 'installSpec';
+            },
+        ) => {
+            return await make.sdk.connections.getSection(args.connectionName, args.section);
+        },
+    },
+    {
+        name: 'sdk_connections_set_section',
+        title: 'Set SDK connection section',
+        description: 'Set a specific section of a connection',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionName: { type: 'string', description: 'The name of the connection' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'parameters', 'scopes', 'scope', 'install', 'installSpec'],
+                    description: 'The section to set',
+                },
+                body: { type: 'object', description: 'The section data to set' },
+            },
+            required: ['connectionName', 'section', 'body'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                connectionName: string;
+                section: 'api' | 'parameters' | 'scopes' | 'scope' | 'install' | 'installSpec';
+                body: Record<string, JSONValue> | Array<Record<string, JSONValue>>;
+            },
+        ) => {
+            return await make.sdk.connections.setSection(args.connectionName, args.section, args.body);
+        },
+    },
+    {
+        name: 'sdk_connections_get_common',
+        title: 'Get SDK connection common data',
+        description: 'Get common configuration for a connection',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionName: { type: 'string', description: 'The name of the connection' },
+            },
+            required: ['connectionName'],
+        },
+        execute: async (make: Make, args: { connectionName: string }) => {
+            return await make.sdk.connections.getCommon(args.connectionName);
+        },
+    },
+    {
+        name: 'sdk_connections_set_common',
+        title: 'Set SDK connection common data',
+        description: 'Set common configuration for a connection',
+        category: 'sdk.connections',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                connectionName: { type: 'string', description: 'The name of the connection' },
+                common: { type: 'object', description: 'The common data to set' },
+            },
+            required: ['connectionName', 'common'],
+        },
+        execute: async (make: Make, args: { connectionName: string; common: Record<string, JSONValue> }) => {
+            return await make.sdk.connections.setCommon(args.connectionName, args.common);
+        },
+    },
+];

--- a/src/endpoints/sdk/functions.mcp.ts
+++ b/src/endpoints/sdk/functions.mcp.ts
@@ -1,0 +1,172 @@
+import type { Make } from '../../make.js';
+
+export const tools = [
+    {
+        name: 'sdk_functions_list',
+        title: 'List SDK functions',
+        description: 'List functions for the app',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+            },
+            required: ['appName', 'appVersion'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number }) => {
+            return await make.sdk.functions.list(args.appName, args.appVersion);
+        },
+    },
+    {
+        name: 'sdk_functions_get',
+        title: 'Get SDK function',
+        description: 'Get a single function by name',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                functionName: { type: 'string', description: 'The name of the function' },
+            },
+            required: ['appName', 'appVersion', 'functionName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; functionName: string }) => {
+            return await make.sdk.functions.get(args.appName, args.appVersion, args.functionName);
+        },
+    },
+    {
+        name: 'sdk_functions_create',
+        title: 'Create SDK function',
+        description: 'Create a new function',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                name: { type: 'string', description: 'The name of the function' },
+            },
+            required: ['appName', 'appVersion', 'name'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; name: string }) => {
+            const { appName, appVersion, ...body } = args;
+            return await make.sdk.functions.create(appName, appVersion, body);
+        },
+    },
+    {
+        name: 'sdk_functions_delete',
+        title: 'Delete SDK function',
+        description: 'Delete a function',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                functionName: { type: 'string', description: 'The name of the function' },
+            },
+            required: ['appName', 'appVersion', 'functionName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; functionName: string }) => {
+            return await make.sdk.functions.delete(args.appName, args.appVersion, args.functionName);
+        },
+    },
+    {
+        name: 'sdk_functions_get_code',
+        title: 'Get SDK function code',
+        description: 'Get function code',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                functionName: { type: 'string', description: 'The name of the function' },
+            },
+            required: ['appName', 'appVersion', 'functionName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; functionName: string }) => {
+            return await make.sdk.functions.getCode(args.appName, args.appVersion, args.functionName);
+        },
+    },
+    {
+        name: 'sdk_functions_set_code',
+        title: 'Set SDK function code',
+        description: 'Set/update function code',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                functionName: { type: 'string', description: 'The name of the function' },
+                code: { type: 'string', description: 'The function code' },
+            },
+            required: ['appName', 'appVersion', 'functionName', 'code'],
+        },
+        execute: async (
+            make: Make,
+            args: { appName: string; appVersion: number; functionName: string; code: string },
+        ) => {
+            return await make.sdk.functions.setCode(args.appName, args.appVersion, args.functionName, args.code);
+        },
+    },
+    {
+        name: 'sdk_functions_get_test',
+        title: 'Get SDK function test',
+        description: 'Get function test code',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                functionName: { type: 'string', description: 'The name of the function' },
+            },
+            required: ['appName', 'appVersion', 'functionName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; functionName: string }) => {
+            return await make.sdk.functions.getTest(args.appName, args.appVersion, args.functionName);
+        },
+    },
+    {
+        name: 'sdk_functions_set_test',
+        title: 'Set SDK function test',
+        description: 'Set/update function test code',
+        category: 'sdk.functions',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                functionName: { type: 'string', description: 'The name of the function' },
+                test: { type: 'string', description: 'The test code' },
+            },
+            required: ['appName', 'appVersion', 'functionName', 'test'],
+        },
+        execute: async (
+            make: Make,
+            args: { appName: string; appVersion: number; functionName: string; test: string },
+        ) => {
+            return await make.sdk.functions.setTest(args.appName, args.appVersion, args.functionName, args.test);
+        },
+    },
+];

--- a/src/endpoints/sdk/modules.mcp.ts
+++ b/src/endpoints/sdk/modules.mcp.ts
@@ -1,0 +1,212 @@
+import type { Make } from '../../make.js';
+import type { JSONValue } from '../../types.js';
+
+export const tools = [
+    {
+        name: 'sdk_modules_list',
+        title: 'List SDK modules',
+        description: 'List modules for the app with optional filtering',
+        category: 'sdk.modules',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+            },
+            required: ['appName', 'appVersion'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number }) => {
+            return await make.sdk.modules.list(args.appName, args.appVersion);
+        },
+    },
+    {
+        name: 'sdk_modules_get',
+        title: 'Get SDK module',
+        description: 'Get a single module by name',
+        category: 'sdk.modules',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                moduleName: { type: 'string', description: 'The name of the module' },
+            },
+            required: ['appName', 'appVersion', 'moduleName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; moduleName: string }) => {
+            return await make.sdk.modules.get(args.appName, args.appVersion, args.moduleName);
+        },
+    },
+    {
+        name: 'sdk_modules_create',
+        title: 'Create SDK module',
+        description: 'Create a new module',
+        category: 'sdk.modules',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                name: { type: 'string', description: 'The name of the module' },
+                typeId: { type: 'number', description: 'The type ID of the module' },
+                label: { type: 'string', description: 'The label of the module visible in the scenario builder' },
+                description: { type: 'string', description: 'The description of the module' },
+                moduleInitMode: {
+                    type: 'string',
+                    enum: ['blank', 'example', 'module'],
+                    description: 'Module initialization mode',
+                },
+            },
+            required: ['appName', 'appVersion', 'name', 'typeId', 'label', 'description'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                name: string;
+                typeId: number;
+                label: string;
+                description: string;
+                moduleInitMode?: 'blank' | 'example' | 'module';
+            },
+        ) => {
+            const { appName, appVersion, ...body } = args;
+            return await make.sdk.modules.create(appName, appVersion, body);
+        },
+    },
+    {
+        name: 'sdk_modules_update',
+        title: 'Update SDK module',
+        description: 'Update an existing module',
+        category: 'sdk.modules',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                moduleName: { type: 'string', description: 'The name of the module' },
+                label: { type: 'string', description: 'The label of the module visible in the scenario builder' },
+                description: { type: 'string', description: 'The description of the module' },
+                connection: { type: 'string', description: 'Connection name' },
+            },
+            required: ['appName', 'appVersion', 'moduleName'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                moduleName: string;
+                label?: string;
+                description?: string;
+                connection?: string;
+            },
+        ) => {
+            const { appName, appVersion, moduleName, ...body } = args;
+            return await make.sdk.modules.update(appName, appVersion, moduleName, body);
+        },
+    },
+    {
+        name: 'sdk_modules_delete',
+        title: 'Delete SDK module',
+        description: 'Delete a module',
+        category: 'sdk.modules',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                moduleName: { type: 'string', description: 'The name of the module' },
+            },
+            required: ['appName', 'appVersion', 'moduleName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; moduleName: string }) => {
+            return await make.sdk.modules.delete(args.appName, args.appVersion, args.moduleName);
+        },
+    },
+    {
+        name: 'sdk_modules_get_section',
+        title: 'Get SDK module section',
+        description: 'Get a specific section of a module',
+        category: 'sdk.modules',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                moduleName: { type: 'string', description: 'The name of the module' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'epoch', 'parameters', 'expect', 'interface', 'samples', 'scope'],
+                    description: 'The section to get',
+                },
+            },
+            required: ['appName', 'appVersion', 'moduleName', 'section'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                moduleName: string;
+                section: 'api' | 'epoch' | 'parameters' | 'expect' | 'interface' | 'samples' | 'scope';
+            },
+        ) => {
+            return await make.sdk.modules.getSection(args.appName, args.appVersion, args.moduleName, args.section);
+        },
+    },
+    {
+        name: 'sdk_modules_set_section',
+        title: 'Set SDK module section',
+        description: 'Set/update a specific section of a module',
+        category: 'sdk.modules',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                moduleName: { type: 'string', description: 'The name of the module' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'epoch', 'parameters', 'expect', 'interface', 'samples', 'scope'],
+                    description: 'The section to set',
+                },
+                body: { type: 'object', description: 'The section data to set' },
+            },
+            required: ['appName', 'appVersion', 'moduleName', 'section', 'body'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                moduleName: string;
+                section: 'api' | 'epoch' | 'parameters' | 'expect' | 'interface' | 'samples' | 'scope';
+                body: Record<string, JSONValue> | Array<Record<string, JSONValue>>;
+            },
+        ) => {
+            return await make.sdk.modules.setSection(
+                args.appName,
+                args.appVersion,
+                args.moduleName,
+                args.section,
+                args.body,
+            );
+        },
+    },
+];

--- a/src/endpoints/sdk/rpcs.mcp.ts
+++ b/src/endpoints/sdk/rpcs.mcp.ts
@@ -1,0 +1,236 @@
+import type { Make } from '../../make.js';
+import type { JSONValue } from '../../types.js';
+
+export const tools = [
+    {
+        name: 'sdk_rpcs_list',
+        title: 'List SDK RPCs',
+        description: 'List all RPCs for the app',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+            },
+            required: ['appName', 'appVersion'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number }) => {
+            return await make.sdk.rpcs.list(args.appName, args.appVersion);
+        },
+    },
+    {
+        name: 'sdk_rpcs_get',
+        title: 'Get SDK RPC',
+        description: 'Get a single RPC by name',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                rpcName: { type: 'string', description: 'The name of the RPC' },
+            },
+            required: ['appName', 'appVersion', 'rpcName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; rpcName: string }) => {
+            return await make.sdk.rpcs.get(args.appName, args.appVersion, args.rpcName);
+        },
+    },
+    {
+        name: 'sdk_rpcs_create',
+        title: 'Create SDK RPC',
+        description: 'Create a new RPC',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                name: { type: 'string', description: 'The name of the RPC' },
+                label: { type: 'string', description: 'The label of the RPC visible in the scenario builder' },
+            },
+            required: ['appName', 'appVersion', 'name', 'label'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; name: string; label: string }) => {
+            const { appName, appVersion, ...body } = args;
+            return await make.sdk.rpcs.create(appName, appVersion, body);
+        },
+    },
+    {
+        name: 'sdk_rpcs_update',
+        title: 'Update SDK RPC',
+        description: 'Update an existing RPC',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                rpcName: { type: 'string', description: 'The name of the RPC' },
+                label: { type: 'string', description: 'The label of the RPC visible in the scenario builder' },
+                connection: { type: 'string', description: 'Connection name' },
+                altConnection: { type: 'string', description: 'Alternative connection name' },
+            },
+            required: ['appName', 'appVersion', 'rpcName'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                rpcName: string;
+                label?: string;
+                connection?: string;
+                altConnection?: string;
+            },
+        ) => {
+            const { appName, appVersion, rpcName, ...body } = args;
+            return await make.sdk.rpcs.update(appName, appVersion, rpcName, body);
+        },
+    },
+    {
+        name: 'sdk_rpcs_delete',
+        title: 'Delete SDK RPC',
+        description: 'Delete an RPC',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                rpcName: { type: 'string', description: 'The name of the RPC' },
+            },
+            required: ['appName', 'appVersion', 'rpcName'],
+        },
+        execute: async (make: Make, args: { appName: string; appVersion: number; rpcName: string }) => {
+            return await make.sdk.rpcs.delete(args.appName, args.appVersion, args.rpcName);
+        },
+    },
+    {
+        name: 'sdk_rpcs_test',
+        title: 'Test SDK RPC',
+        description: 'Test an RPC with provided data and schema',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                rpcName: { type: 'string', description: 'The name of the RPC' },
+                data: { type: 'object', description: 'Test data object' },
+                schema: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            name: { type: 'string', description: 'Parameter name' },
+                            type: { type: 'string', description: 'Parameter type' },
+                            required: { type: 'boolean', description: 'Whether parameter is required' },
+                        },
+                        required: ['name', 'type', 'required'],
+                    },
+                    description: 'Schema definition array',
+                },
+            },
+            required: ['appName', 'appVersion', 'rpcName', 'data', 'schema'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                rpcName: string;
+                data: Record<string, JSONValue>;
+                schema: Array<{
+                    name: string;
+                    type: string;
+                    required: boolean;
+                }>;
+            },
+        ) => {
+            const { appName, appVersion, rpcName, ...body } = args;
+            return await make.sdk.rpcs.test(appName, appVersion, rpcName, body);
+        },
+    },
+    {
+        name: 'sdk_rpcs_get_section',
+        title: 'Get SDK RPC section',
+        description: 'Get RPC section data',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                rpcName: { type: 'string', description: 'The name of the RPC' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'parameters'],
+                    description: 'The section to get',
+                },
+            },
+            required: ['appName', 'appVersion', 'rpcName', 'section'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                rpcName: string;
+                section: 'api' | 'parameters';
+            },
+        ) => {
+            return await make.sdk.rpcs.getSection(args.appName, args.appVersion, args.rpcName, args.section);
+        },
+    },
+    {
+        name: 'sdk_rpcs_set_section',
+        title: 'Set SDK RPC section',
+        description: 'Set RPC section data',
+        category: 'sdk.rpcs',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                appVersion: { type: 'number', description: 'The version of the app' },
+                rpcName: { type: 'string', description: 'The name of the RPC' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'parameters'],
+                    description: 'The section to set',
+                },
+                body: { type: 'object', description: 'The section data to set' },
+            },
+            required: ['appName', 'appVersion', 'rpcName', 'section', 'body'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                appName: string;
+                appVersion: number;
+                rpcName: string;
+                section: 'api' | 'parameters';
+                body: Record<string, JSONValue> | Array<Record<string, JSONValue>>;
+            },
+        ) => {
+            return await make.sdk.rpcs.setSection(args.appName, args.appVersion, args.rpcName, args.section, args.body);
+        },
+    },
+];

--- a/src/endpoints/sdk/webhooks.mcp.ts
+++ b/src/endpoints/sdk/webhooks.mcp.ts
@@ -1,0 +1,160 @@
+import type { Make } from '../../make.js';
+import type { JSONValue } from '../../types.js';
+
+export const tools = [
+    {
+        name: 'sdk_webhooks_list',
+        title: 'List SDK webhooks',
+        description: 'List webhooks for a specific app',
+        category: 'sdk.webhooks',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+            },
+            required: ['appName'],
+        },
+        execute: async (make: Make, args: { appName: string }) => {
+            return await make.sdk.webhooks.list(args.appName);
+        },
+    },
+    {
+        name: 'sdk_webhooks_get',
+        title: 'Get SDK webhook',
+        description: 'Get a single webhook by name',
+        category: 'sdk.webhooks',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                webhookName: { type: 'string', description: 'The name of the webhook' },
+            },
+            required: ['webhookName'],
+        },
+        execute: async (make: Make, args: { webhookName: string }) => {
+            return await make.sdk.webhooks.get(args.webhookName);
+        },
+    },
+    {
+        name: 'sdk_webhooks_create',
+        title: 'Create SDK webhook',
+        description: 'Create a new webhook for an app',
+        category: 'sdk.webhooks',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                appName: { type: 'string', description: 'The name of the app' },
+                type: { type: 'string', description: 'The type of the webhook' },
+                label: { type: 'string', description: 'The label of the webhook visible in the scenario builder' },
+            },
+            required: ['appName', 'type', 'label'],
+        },
+        execute: async (make: Make, args: { appName: string; type: string; label: string }) => {
+            const { appName, ...body } = args;
+            return await make.sdk.webhooks.create(appName, body);
+        },
+    },
+    {
+        name: 'sdk_webhooks_update',
+        title: 'Update SDK webhook',
+        description: 'Update an existing webhook',
+        category: 'sdk.webhooks',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                webhookName: { type: 'string', description: 'The name of the webhook' },
+                label: { type: 'string', description: 'The label of the webhook visible in the scenario builder' },
+            },
+            required: ['webhookName'],
+        },
+        execute: async (make: Make, args: { webhookName: string; label?: string }) => {
+            const { webhookName, ...body } = args;
+            return await make.sdk.webhooks.update(webhookName, body);
+        },
+    },
+    {
+        name: 'sdk_webhooks_delete',
+        title: 'Delete SDK webhook',
+        description: 'Delete a webhook',
+        category: 'sdk.webhooks',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                webhookName: { type: 'string', description: 'The name of the webhook' },
+            },
+            required: ['webhookName'],
+        },
+        execute: async (make: Make, args: { webhookName: string }) => {
+            return await make.sdk.webhooks.delete(args.webhookName);
+        },
+    },
+    {
+        name: 'sdk_webhooks_get_section',
+        title: 'Get SDK webhook section',
+        description: 'Get a specific section of a webhook',
+        category: 'sdk.webhooks',
+        scope: 'sdk-apps:read',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                webhookName: { type: 'string', description: 'The name of the webhook' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'parameters', 'attach', 'detach', 'scope'],
+                    description: 'The section to get',
+                },
+            },
+            required: ['webhookName', 'section'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                webhookName: string;
+                section: 'api' | 'parameters' | 'attach' | 'detach' | 'scope';
+            },
+        ) => {
+            return await make.sdk.webhooks.getSection(args.webhookName, args.section);
+        },
+    },
+    {
+        name: 'sdk_webhooks_set_section',
+        title: 'Set SDK webhook section',
+        description: 'Set a specific section of a webhook',
+        category: 'sdk.webhooks',
+        scope: 'sdk-apps:write',
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                webhookName: { type: 'string', description: 'The name of the webhook' },
+                section: {
+                    type: 'string',
+                    enum: ['api', 'parameters', 'attach', 'detach', 'scope'],
+                    description: 'The section to set',
+                },
+                body: { type: 'object', description: 'The section data to set' },
+            },
+            required: ['webhookName', 'section', 'body'],
+        },
+        execute: async (
+            make: Make,
+            args: {
+                webhookName: string;
+                section: 'api' | 'parameters' | 'attach' | 'detach' | 'scope';
+                body: Record<string, JSONValue> | Array<Record<string, JSONValue>>;
+            },
+        ) => {
+            return await make.sdk.webhooks.setSection(args.webhookName, args.section, args.body);
+        },
+    },
+];

--- a/src/endpoints/teams.mcp.ts
+++ b/src/endpoints/teams.mcp.ts
@@ -1,0 +1,85 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'teams_list',
+        title: 'List teams',
+        description: 'List teams for the current user',
+        category: 'teams',
+        scope: 'teams:read',
+        identifier: 'organizationId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                organizationId: { type: 'number', description: 'The organization ID to list teams for' },
+            },
+            required: ['organizationId'],
+        },
+        execute: async (make: Make, args: { organizationId: number }) => {
+            return await make.teams.list(args.organizationId);
+        },
+    },
+    {
+        name: 'teams_get',
+        title: 'Get team',
+        description: 'Get details of a specific team',
+        category: 'teams',
+        scope: 'teams:read',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to retrieve' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.teams.get(args.teamId);
+        },
+    },
+    {
+        name: 'teams_create',
+        title: 'Create team',
+        description: 'Create a new team',
+        category: 'teams',
+        scope: 'teams:write',
+        identifier: 'organizationId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'Name for the new team' },
+                organizationId: {
+                    type: 'number',
+                    description: 'ID of the organization where the team will be created',
+                },
+                operationsLimit: { type: 'number', description: 'Maximum operations limit for the team' },
+                transferLimit: { type: 'number', description: 'Maximum data transfer limit for the team' },
+            },
+            required: ['name', 'organizationId'],
+        },
+        execute: async (
+            make: Make,
+            args: { name: string; organizationId: number; operationsLimit?: number; transferLimit?: number },
+        ) => {
+            return await make.teams.create(args);
+        },
+    },
+    {
+        name: 'teams_delete',
+        title: 'Delete team',
+        description: 'Delete a team',
+        category: 'teams',
+        scope: 'teams:write',
+        identifier: 'teamId',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to delete' },
+            },
+            required: ['teamId'],
+        },
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.teams.delete(args.teamId);
+        },
+    },
+];

--- a/src/endpoints/users.mcp.ts
+++ b/src/endpoints/users.mcp.ts
@@ -1,0 +1,32 @@
+import type { Make } from '../make.js';
+
+export const tools = [
+    {
+        name: 'users_me',
+        title: 'Get current user',
+        description: 'Get details of the current user',
+        category: 'users',
+        scope: undefined,
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+        },
+        execute: async (make: Make) => {
+            return await make.users.me();
+        },
+    },
+    {
+        name: 'users_current_authorization',
+        title: 'Get current authorization',
+        description: 'Get authorization details for the current user',
+        category: 'users',
+        scope: undefined,
+        identifier: undefined,
+        inputSchema: {
+            type: 'object',
+        },
+        execute: async (make: Make) => {
+            return await make.users.currentAuthorization();
+        },
+    },
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export type {
     CreateScenarioOptions,
     UpdateScenarioBody,
     UpdateScenarioOptions,
+    UpdateScenarioInterfaceBody,
     RunScenarioResponse,
     Scheduling,
 } from './endpoints/scenarios.js';

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,51 @@
+import { tools as SDKAppsTools } from './endpoints/sdk/apps.mcp.js';
+import { tools as SDKConnectionsTools } from './endpoints/sdk/connections.mcp.js';
+import { tools as SDKFunctionsTools } from './endpoints/sdk/functions.mcp.js';
+import { tools as SDKModulesTools } from './endpoints/sdk/modules.mcp.js';
+import { tools as SDKRPCsTools } from './endpoints/sdk/rpcs.mcp.js';
+import { tools as SDKWebhooksTools } from './endpoints/sdk/webhooks.mcp.js';
+
+import { tools as ScenariosTools } from './endpoints/scenarios.mcp.js';
+import { tools as ConnectionsTools } from './endpoints/connections.mcp.js';
+import { tools as DataStoresTools } from './endpoints/data-stores.mcp.js';
+import { tools as DataStoreRecordsTools } from './endpoints/data-store-records.mcp.js';
+import { tools as BlueprintsTools } from './endpoints/blueprints.mcp.js';
+import { tools as TeamsTools } from './endpoints/teams.mcp.js';
+import { tools as OrganizationsTools } from './endpoints/organizations.mcp.js';
+import { tools as UsersTools } from './endpoints/users.mcp.js';
+import { tools as FunctionsTools } from './endpoints/functions.mcp.js';
+import { tools as ExecutionsTools } from './endpoints/executions.mcp.js';
+import { tools as HooksTools } from './endpoints/hooks.mcp.js';
+import { tools as KeysTools } from './endpoints/keys.mcp.js';
+import { tools as FoldersTools } from './endpoints/folders.mcp.js';
+import { tools as IncompleteExecutionsTools } from './endpoints/incomplete-executions.mcp.js';
+import { tools as DataStructuresTools } from './endpoints/data-structures.mcp.js';
+import { tools as EnumsTools } from './endpoints/enums.mcp.js';
+
+export const MakeMCPTools = [
+    // SDK Tools
+    ...SDKAppsTools,
+    ...SDKConnectionsTools,
+    ...SDKFunctionsTools,
+    ...SDKModulesTools,
+    ...SDKRPCsTools,
+    ...SDKWebhooksTools,
+
+    // Core Endpoint Tools
+    ...ScenariosTools,
+    ...ConnectionsTools,
+    ...DataStoresTools,
+    ...DataStoreRecordsTools,
+    ...BlueprintsTools,
+    ...TeamsTools,
+    ...OrganizationsTools,
+    ...UsersTools,
+    ...FunctionsTools,
+    ...ExecutionsTools,
+    ...HooksTools,
+    ...KeysTools,
+    ...FoldersTools,
+    ...IncompleteExecutionsTools,
+    ...DataStructuresTools,
+    ...EnumsTools,
+];

--- a/test/data-store-records.integration.test.ts
+++ b/test/data-store-records.integration.test.ts
@@ -1,0 +1,254 @@
+import 'dotenv/config';
+import { describe, expect, it } from '@jest/globals';
+import { Make } from '../src/make.js';
+
+const MAKE_API_KEY = String(process.env.MAKE_API_KEY || '');
+const MAKE_ZONE = String(process.env.MAKE_ZONE || '');
+const MAKE_TEAM = Number(process.env.MAKE_TEAM || 0);
+
+describe('Integration: Data Store Records', () => {
+    const make = new Make(MAKE_API_KEY, MAKE_ZONE);
+
+    let dataStoreId: number;
+    let dataStructureId: number;
+    let recordKey1: string;
+    let recordKey2: string;
+    let recordKey3: string;
+
+    it('Should create a data structure for testing', async () => {
+        const dataStructure = await make.dataStructures.create({
+            name: `DataStore Records Test Structure ${Date.now()}`,
+            teamId: MAKE_TEAM,
+            spec: [
+                {
+                    type: 'text',
+                    name: 'name',
+                    label: 'Name',
+                    required: true,
+                },
+                {
+                    type: 'text',
+                    name: 'email',
+                    label: 'Email',
+                    required: true,
+                },
+                {
+                    type: 'text',
+                    name: 'status',
+                    label: 'Status',
+                    required: false,
+                },
+                {
+                    type: 'number',
+                    name: 'age',
+                    label: 'Age',
+                    required: false,
+                },
+                {
+                    type: 'text',
+                    name: 'department',
+                    label: 'Department',
+                    required: false,
+                },
+            ],
+            strict: true,
+        });
+
+        expect(dataStructure).toBeDefined();
+        expect(dataStructure.id).toBeDefined();
+        dataStructureId = dataStructure.id;
+    });
+
+    it('Should create a data store for testing', async () => {
+        const dataStore = await make.dataStores.create({
+            name: `Test DataStore Records ${Date.now()}`,
+            teamId: MAKE_TEAM,
+            datastructureId: dataStructureId,
+            maxSizeMB: 1,
+        });
+
+        expect(dataStore).toBeDefined();
+        expect(dataStore.id).toBeDefined();
+        dataStoreId = dataStore.id;
+    });
+
+    it('Should create a record with auto-generated key', async () => {
+        const recordData = {
+            name: 'John Doe',
+            email: 'john.doe@example.com',
+            status: 'active',
+            age: 30,
+            department: 'Engineering',
+        };
+
+        const record = await make.dataStores.records.create(dataStoreId, recordData);
+
+        expect(record).toBeDefined();
+        expect(record.key).toBeDefined();
+        expect(typeof record.key).toBe('string');
+        expect(record.data).toEqual(recordData);
+
+        recordKey1 = record.key;
+    });
+
+    it('Should create a record with explicit key', async () => {
+        const customKey = `custom_key_${Date.now()}`;
+        const recordData = {
+            name: 'Jane Smith',
+            email: 'jane.smith@example.com',
+            status: 'inactive',
+            age: 28,
+            department: 'Marketing',
+        };
+
+        const record = await make.dataStores.records.create(dataStoreId, customKey, recordData);
+
+        expect(record).toBeDefined();
+        expect(record.key).toBe(customKey);
+        expect(record.data).toEqual(recordData);
+
+        recordKey2 = record.key;
+    });
+
+    it('Should create another record for bulk operations testing', async () => {
+        const recordData = {
+            name: 'Bob Johnson',
+            email: 'bob.johnson@example.com',
+            status: 'active',
+            age: 35,
+            department: 'Sales',
+        };
+
+        const record = await make.dataStores.records.create(dataStoreId, recordData);
+
+        expect(record).toBeDefined();
+        expect(record.key).toBeDefined();
+        recordKey3 = record.key;
+    });
+
+    it('Should list all records in the data store', async () => {
+        const records = await make.dataStores.records.list(dataStoreId);
+
+        expect(records).toBeDefined();
+        expect(Array.isArray(records)).toBe(true);
+        expect(records.length).toBeGreaterThanOrEqual(3);
+
+        // Verify our created records exist
+        const record1 = records.find(r => r.key === recordKey1);
+        const record2 = records.find(r => r.key === recordKey2);
+        const record3 = records.find(r => r.key === recordKey3);
+
+        expect(record1).toBeDefined();
+        expect(record1?.data.name).toBe('John Doe');
+
+        expect(record2).toBeDefined();
+        expect(record2?.data.name).toBe('Jane Smith');
+
+        expect(record3).toBeDefined();
+        expect(record3?.data.name).toBe('Bob Johnson');
+    });
+
+    it('Should list records with pagination', async () => {
+        const records = await make.dataStores.records.list(dataStoreId, {
+            pg: {
+                limit: 2,
+                offset: 0,
+            },
+        });
+
+        expect(records).toBeDefined();
+        expect(Array.isArray(records)).toBe(true);
+        expect(records.length).toBeLessThanOrEqual(2);
+    });
+
+    it('Should update a record partially', async () => {
+        const updateData = {
+            status: 'on-leave',
+            department: 'HR',
+        };
+
+        const updatedRecord = await make.dataStores.records.update(dataStoreId, recordKey1, updateData);
+
+        expect(updatedRecord).toBeDefined();
+        expect(updatedRecord.key).toBe(recordKey1);
+        expect(updatedRecord.data.status).toBe('on-leave');
+        expect(updatedRecord.data.department).toBe('HR');
+        // Original data should be preserved
+        expect(updatedRecord.data.name).toBe('John Doe');
+        expect(updatedRecord.data.email).toBe('john.doe@example.com');
+        expect(updatedRecord.data.age).toBe(30);
+    });
+
+    it('Should replace a record completely', async () => {
+        const replaceData = {
+            name: 'Jane Smith-Updated',
+            email: 'jane.updated@example.com',
+            status: 'active',
+            age: 29,
+            department: 'Product',
+        };
+
+        const replacedRecord = await make.dataStores.records.replace(dataStoreId, recordKey2, replaceData);
+
+        expect(replacedRecord).toBeDefined();
+        expect(replacedRecord.key).toBe(recordKey2);
+        expect(replacedRecord.data).toEqual(replaceData);
+    });
+
+    it('Should delete a single record', async () => {
+        await make.dataStores.records.delete(dataStoreId, [recordKey3]);
+
+        // Verify the record is deleted
+        const records = await make.dataStores.records.list(dataStoreId);
+        const deletedRecord = records.find(r => r.key === recordKey3);
+        expect(deletedRecord).toBeUndefined();
+
+        // Other records should still exist
+        const record1 = records.find(r => r.key === recordKey1);
+        const record2 = records.find(r => r.key === recordKey2);
+        expect(record1).toBeDefined();
+        expect(record2).toBeDefined();
+    });
+
+    it('Should delete multiple records', async () => {
+        await make.dataStores.records.delete(dataStoreId, [recordKey1, recordKey2]);
+
+        // Verify both records are deleted
+        const records = await make.dataStores.records.list(dataStoreId);
+        const deletedRecord1 = records.find(r => r.key === recordKey1);
+        const deletedRecord2 = records.find(r => r.key === recordKey2);
+
+        expect(deletedRecord1).toBeUndefined();
+        expect(deletedRecord2).toBeUndefined();
+    });
+
+    it('Should verify data store is empty after deleting all records', async () => {
+        const records = await make.dataStores.records.list(dataStoreId);
+        expect(records.length).toBe(0);
+    });
+
+    // Cleanup
+    it('Should delete the test data store', async () => {
+        await make.dataStores.delete(dataStoreId);
+
+        // Verify deletion by expecting an error when trying to access it
+        try {
+            await make.dataStores.get(dataStoreId);
+            expect(true).toBe(false); // Should not reach this line
+        } catch (error) {
+            expect(error).toBeDefined();
+        }
+    });
+
+    it('Should delete the test data structure', async () => {
+        await make.dataStructures.delete(dataStructureId);
+
+        // Verify deletion by expecting an error when trying to access it
+        try {
+            await make.dataStructures.get(dataStructureId);
+            expect(true).toBe(false); // Should not reach this line
+        } catch (error) {
+            expect(error).toBeDefined();
+        }
+    });
+});

--- a/test/data-store-records.spec.ts
+++ b/test/data-store-records.spec.ts
@@ -92,23 +92,4 @@ describe('Endpoints: DataStoreRecords', () => {
 
         await make.dataStores.records.delete(137, keys);
     });
-
-    it('Should delete all records from a data store', async () => {
-        mockFetch('DELETE https://make.local/api/v2/data-stores/137/data?confirmed=true', null);
-
-        await make.dataStores.records.deleteAll(137);
-    });
-
-    it('Should delete all records except specified ones from a data store', async () => {
-        const exceptKeys = ['8f7162828bc0'];
-
-        mockFetch('DELETE https://make.local/api/v2/data-stores/137/data?confirmed=true', null, req => {
-            expect(req.body).toStrictEqual({
-                all: true,
-                exceptKeys,
-            });
-        });
-
-        await make.dataStores.records.deleteAll(137, exceptKeys);
-    });
 });

--- a/test/data-store.integration.test.ts
+++ b/test/data-store.integration.test.ts
@@ -185,14 +185,6 @@ describe('Integration: Data Stores', () => {
         expect(remainingRecord).toBeDefined();
     });
 
-    it('Should delete all records from a data store', async () => {
-        await make.dataStores.records.deleteAll(dataStoreId);
-
-        // Verify all records are deleted
-        const records = await make.dataStores.records.list(dataStoreId);
-        expect(records.length).toBe(0);
-    });
-
     it('Should delete a data store', async () => {
         await make.dataStores.delete(dataStoreId);
 

--- a/test/incomplete-executions.spec.ts
+++ b/test/incomplete-executions.spec.ts
@@ -14,9 +14,9 @@ describe('Endpoints: IncompleteExecutions', () => {
     const make = new Make(MAKE_API_KEY, MAKE_ZONE);
 
     it('Should list incomplete executions', async () => {
-        mockFetch('GET https://make.local/api/v2/dlqs', listMock);
+        mockFetch('GET https://make.local/api/v2/dlqs?scenarioId=1', listMock);
 
-        const result = await make.incompleteExecutions.list();
+        const result = await make.incompleteExecutions.list(1);
 
         expect(result).toStrictEqual(listMock.dlqs);
     });

--- a/test/mcp.spec.ts
+++ b/test/mcp.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from '@jest/globals';
+import { MakeMCPTools } from '../src/mcp.js';
+
+describe('MCP Tools', () => {
+    it('Should export MakeMCPTools array', () => {
+        expect(MakeMCPTools).toBeDefined();
+        expect(Array.isArray(MakeMCPTools)).toBe(true);
+        expect(MakeMCPTools.length).toBeGreaterThan(0);
+    });
+
+    it('Should have a reasonable number of tools', () => {
+        // With all the endpoints, we should have a significant number of tools
+        expect(MakeMCPTools.length).toBeGreaterThan(50);
+        expect(MakeMCPTools.length).toBeLessThan(500); // Sanity check
+    });
+
+    it('Should have tools with required properties', () => {
+        MakeMCPTools.forEach(tool => {
+            // Test required properties exist
+            expect(tool).toHaveProperty('name');
+            expect(tool).toHaveProperty('title');
+            expect(tool).toHaveProperty('description');
+            expect(tool).toHaveProperty('category');
+            expect(tool).toHaveProperty('inputSchema');
+            expect(tool).toHaveProperty('execute');
+
+            // Test property types
+            expect(typeof tool.name).toBe('string');
+            expect(typeof tool.title).toBe('string');
+            expect(typeof tool.description).toBe('string');
+            expect(typeof tool.category).toBe('string');
+            expect(typeof tool.inputSchema).toBe('object');
+            expect(typeof tool.execute).toBe('function');
+
+            // Test that required string properties are not empty
+            expect(tool.name.length).toBeGreaterThan(0);
+            expect(tool.title.length).toBeGreaterThan(0);
+            expect(tool.description.length).toBeGreaterThan(0);
+            expect(tool.category.length).toBeGreaterThan(0);
+
+            // Scope is optional, but if present should be a string
+            if (tool.scope !== undefined) {
+                expect(typeof tool.scope).toBe('string');
+                expect(tool.scope.length).toBeGreaterThan(0);
+            }
+        });
+    });
+
+    it('Should have unique tool names', () => {
+        const names = MakeMCPTools.map(tool => tool.name);
+        const uniqueNames = new Set(names);
+
+        expect(uniqueNames.size).toBe(names.length);
+
+        // If there are duplicates, find and report them
+        if (uniqueNames.size !== names.length) {
+            const duplicates: string[] = [];
+            const seen = new Set<string>();
+
+            names.forEach(name => {
+                if (seen.has(name) && !duplicates.includes(name)) {
+                    duplicates.push(name);
+                }
+                seen.add(name);
+            });
+
+            fail(`Duplicate tool names found: ${duplicates.join(', ')}`);
+        }
+    });
+
+    it('Should have tools from SDK endpoints', () => {
+        const sdkTools = MakeMCPTools.filter(tool => tool.category.startsWith('sdk.'));
+        expect(sdkTools.length).toBeGreaterThan(0);
+
+        // Check for expected SDK categories
+        const sdkCategories = [...new Set(sdkTools.map(tool => tool.category))];
+        expect(sdkCategories).toContain('sdk.apps');
+        expect(sdkCategories).toContain('sdk.connections');
+        expect(sdkCategories).toContain('sdk.functions');
+        expect(sdkCategories).toContain('sdk.modules');
+        expect(sdkCategories).toContain('sdk.rpcs');
+        expect(sdkCategories).toContain('sdk.webhooks');
+    });
+
+    it('Should have tools from core endpoints', () => {
+        const coreTools = MakeMCPTools.filter(tool => !tool.category.startsWith('sdk.'));
+        expect(coreTools.length).toBeGreaterThan(0);
+
+        // Check for some expected core categories
+        const coreCategories = [...new Set(coreTools.map(tool => tool.category))];
+        expect(coreCategories).toContain('scenarios');
+        expect(coreCategories).toContain('connections');
+        expect(coreCategories).toContain('teams');
+        expect(coreCategories).toContain('data-stores');
+    });
+
+    it('Should have proper naming conventions', () => {
+        MakeMCPTools.forEach(tool => {
+            // Tool names should follow the pattern: {endpoint}_{action} or sdk_{endpoint}_{action}
+            const namePattern = /^(sdk_)?[a-z_]+_[a-z_]+$/;
+            expect(tool.name).toMatch(namePattern);
+
+            // Categories should use dot notation for hierarchy
+            const categoryPattern = /^[a-z][a-z.-]*[a-z]$/;
+            expect(tool.category).toMatch(categoryPattern);
+
+            // SDK categories should start with "sdk."
+            if (tool.name.startsWith('sdk_')) {
+                expect(tool.category).toMatch(/^sdk\./);
+            }
+        });
+    });
+
+    it('Should have valid scope patterns when scope is defined', () => {
+        const toolsWithScope = MakeMCPTools.filter(tool => tool.scope !== undefined);
+        expect(toolsWithScope.length).toBeGreaterThan(0);
+
+        toolsWithScope.forEach(tool => {
+            // Scopes should follow the pattern: {resource}:{permission}
+            const scopePattern = /^[a-z-]+:(read|write)$/;
+            expect(tool.scope).toMatch(scopePattern);
+        });
+    });
+
+    it('Should have consistent execute function signatures', () => {
+        MakeMCPTools.forEach(tool => {
+            // Execute function should take Make instance as first parameter
+            expect(tool.execute.length).toBeGreaterThanOrEqual(1);
+            expect(tool.execute.length).toBeLessThanOrEqual(2);
+
+            // Function should be async
+            expect(tool.execute.constructor.name).toBe('AsyncFunction');
+        });
+    });
+});

--- a/test/mocks/scenarios/update-interface.json
+++ b/test/mocks/scenarios/update-interface.json
@@ -1,0 +1,19 @@
+{
+    "interface": {
+        "input": [
+            {
+                "name": "userName",
+                "type": "text",
+                "default": "John Doe",
+                "required": true,
+                "multiline": false
+            },
+            {
+                "name": "employeeID",
+                "type": "number",
+                "required": false
+            }
+        ],
+        "output": null
+    }
+}

--- a/test/scenarios.integration.test.ts
+++ b/test/scenarios.integration.test.ts
@@ -19,7 +19,7 @@ describe('Integration Tests', () => {
     it('Should create a scenario', async () => {
         const scenario = await make.scenarios.create({
             teamId: MAKE_TEAM,
-            scheduling: '{"type":"immediately"}',
+            scheduling: '{"type":"on-demand"}',
             blueprint: '{"flow":[],"metadata":{},"name":"Test Scenario"}',
         });
 
@@ -47,6 +47,37 @@ describe('Integration Tests', () => {
         expect(scenario).toBeDefined();
         expect(scenario.id).toBe(scenarioId);
         expect(scenario.name).toBe(updatedName);
+    });
+
+    it('Should update scenario interface', async () => {
+        const interfaceBody = {
+            interface: {
+                input: [
+                    {
+                        name: 'testInput',
+                        type: 'text',
+                        default: 'test value',
+                        required: true,
+                        multiline: false,
+                    },
+                ],
+                output: [],
+            },
+        };
+
+        const updatedInterface = await make.scenarios.setInterface(scenarioId, interfaceBody);
+
+        expect(updatedInterface).toBeDefined();
+        expect(updatedInterface.input).toBeDefined();
+        expect(Array.isArray(updatedInterface.input)).toBe(true);
+        expect(updatedInterface.input).toHaveLength(1);
+        expect(updatedInterface.input![0]).toMatchObject({
+            name: 'testInput',
+            type: 'text',
+            default: 'test value',
+            required: true,
+            multiline: false,
+        });
     });
 
     it('Should delete a scenario', async () => {

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -4,6 +4,7 @@ import { mockFetch } from './test.utils.js';
 
 import * as scenariosMock from './mocks/scenarios/list.json';
 import * as scenarioInterfaceMock from './mocks/scenarios/interface.json';
+import * as scenarioUpdateInterfaceMock from './mocks/scenarios/update-interface.json';
 import * as scenarioRunMock from './mocks/scenarios/run.json';
 import * as scenarioActivateMock from './mocks/scenarios/activate.json';
 import * as scenarioCreateMock from './mocks/scenarios/create.json';
@@ -45,6 +46,36 @@ describe('Endpoints: Scenarios', () => {
 
             const result = await make.scenarios['interface'](18);
             expect(result).toStrictEqual(scenarioInterfaceMock.interface);
+        });
+
+        it('Should update scenario interface', async () => {
+            const body = {
+                interface: {
+                    input: [
+                        {
+                            name: 'userName',
+                            type: 'text',
+                            default: 'John Doe',
+                            required: true,
+                            multiline: false,
+                        },
+                        {
+                            name: 'employeeID',
+                            type: 'number',
+                            required: false,
+                        },
+                    ],
+                    output: null,
+                },
+            };
+
+            mockFetch('PATCH https://make.local/api/v2/scenarios/18/interface', scenarioUpdateInterfaceMock, req => {
+                expect(req.body).toStrictEqual(body);
+                expect(req.headers.get('content-type')).toBe('application/json');
+            });
+
+            const result = await make.scenarios.setInterface(18, body);
+            expect(result).toStrictEqual(scenarioUpdateInterfaceMock.interface);
         });
 
         it('Should run scenario', async () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-    entryPoints: ['src/index.ts'],
+    entryPoints: ['src/index.ts', 'src/mcp.ts'],
     format: ['cjs', 'esm'],
     dts: true,
     outDir: 'dist',


### PR DESCRIPTION
All endpoints are now exported as tools and can be used with MCP servers.