### PR TITLE
fix(scenarios): set correct scope for the run endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # system related
 .DS_Store
 .vscode
+.idea
+local
 
 #test related
 coverage

--- a/src/endpoints/scenarios.mcp.ts
+++ b/src/endpoints/scenarios.mcp.ts
@@ -188,7 +188,7 @@ export const tools = [
         title: 'Run scenario',
         description: 'Execute a scenario with optional input data',
         category: 'scenarios',
-        scope: 'scenarios:write',
+        scope: 'scenarios:run',
         identifier: 'scenarioId',
         inputSchema: {
             type: 'object',

--- a/test/mcp.spec.ts
+++ b/test/mcp.spec.ts
@@ -117,7 +117,7 @@ describe('MCP Tools', () => {
 
         toolsWithScope.forEach(tool => {
             // Scopes should follow the pattern: {resource}:{permission}
-            const scopePattern = /^[a-z-]+:(read|write)$/;
+            const scopePattern = /^[a-z-]+:(read|write|run|use)$/;
             expect(tool.scope).toMatch(scopePattern);
         });
     });


### PR DESCRIPTION
We've noticed an inconsistency in the Scenarios MCP Tools, where we're publishing the Scenario Running Tool with `scenarios:write` scope, while it should be `scenarios:run`, so we're patching it.

Also, for us, IntelliJ users, we're adding a few more `.gitignores` 🙏 