### PR TITLE
fix: shorten MCP tool names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "0.7.2",
+            "version": "0.7.3",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",

--- a/src/endpoints/executions.mcp.ts
+++ b/src/endpoints/executions.mcp.ts
@@ -43,7 +43,7 @@ export const tools = [
         },
     },
     {
-        name: 'executions_list_for_incomplete_execution',
+        name: 'executions_list_for_incomp_exec',
         title: 'List executions for incomplete execution',
         description: 'List executions for an incomplete execution',
         category: 'executions',
@@ -66,7 +66,7 @@ export const tools = [
         },
     },
     {
-        name: 'executions_get_for_incomplete_execution',
+        name: 'executions_get_for_incomp_exec',
         title: 'Get execution for incomplete execution',
         description: 'Get execution details for an incomplete execution',
         category: 'executions',

--- a/test/make.spec.ts
+++ b/test/make.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { Make } from '../src/make.js';
 import { mockFetch, TestableMake } from './test.utils.js';
 import { randomUUID } from 'node:crypto';
+import type { QueryValue } from '../src/types.js';
 
 const MAKE_API_KEY = randomUUID();
 const MAKE_ZONE = 'make.local';
@@ -71,8 +72,8 @@ describe('Make SDK', () => {
                     'x-custom-header': 'test',
                 };
             }
-            protected override prepareURL(url: string): string {
-                return url;
+            protected override prepareURL(url: string, query?: Record<string, QueryValue>): string {
+                return this.prepareQuery(url, query);
             }
             protected override async handleRequest(url: string, options?: RequestInit): Promise<Response> {
                 expect(url).toBe('/users/me');


### PR DESCRIPTION
Shortening some MCP tool names for compatibility reasons with MCP clients.