### PR TITLE
fix: enforce required teamId parameter in credential requests list

### DIFF
--- a/src/endpoints/credential-requests.mcp.ts
+++ b/src/endpoints/credential-requests.mcp.ts
@@ -36,9 +36,8 @@ export const tools = [
                 name?: string;
             },
         ) => {
-            const { teamId, ...options } = args;
-            return await make.credentialRequests.list(teamId, {
-                ...options,
+            return await make.credentialRequests.list(args.teamId, {
+                ...args,
                 cols: ['*'],
             });
         },

--- a/src/endpoints/credential-requests.mcp.ts
+++ b/src/endpoints/credential-requests.mcp.ts
@@ -36,12 +36,9 @@ export const tools = [
                 name?: string;
             },
         ) => {
-            return await make.credentialRequests.list({
-                teamId: args.teamId,
-                userId: args.userId,
-                makeProviderId: args.makeProviderId,
-                status: args.status,
-                name: args.name,
+            const { teamId, ...options } = args;
+            return await make.credentialRequests.list(teamId, {
+                ...options,
                 cols: ['*'],
             });
         },

--- a/src/endpoints/credential-requests.mcp.ts
+++ b/src/endpoints/credential-requests.mcp.ts
@@ -24,11 +24,12 @@ export const tools = [
                 status: { type: 'string', description: 'Filter by status' },
                 name: { type: 'string', description: 'Filter by name' },
             },
+            required: ['teamId'],
         },
         execute: async (
             make: Make,
             args: {
-                teamId?: number;
+                teamId: number;
                 userId?: number;
                 makeProviderId?: string | number;
                 status?: string;

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -248,7 +248,7 @@ export class CredentialRequests {
 
         const response = await this.#fetch<{ requests: PickColumns<CredentialRequest, C>[] }>(
             '/credential-requests/requests',
-            { query: { teamId, ...options } },
+            { query: { ...options, teamId } },
         );
         return response.requests;
     }

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -219,7 +219,9 @@ export class CredentialRequests {
     }
 
     /**
-     * List credential requests with optional filtering and pagination
+     * List credential requests for a given team, with optional additional filtering and pagination.
+     *
+     * @param options - Query options. `teamId` is required, the API returns an error if it is omitted.
      */
     async list<C extends keyof CredentialRequest = never>(
         options: ListCredentialRequestsOptions<C>,

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -243,7 +243,7 @@ export class CredentialRequests {
             teamId = teamIdOrOptions;
             options ??= {} as ListCredentialRequestsOptions<C>;
         } else {
-            ({ teamId, ...options } = teamIdOrOptions as { teamId: number } & ListCredentialRequestsOptions<C>);
+            ({ teamId, ...options } = teamIdOrOptions);
         }
 
         const response = await this.#fetch<{ requests: PickColumns<CredentialRequest, C>[] }>(

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -224,8 +224,28 @@ export class CredentialRequests {
      */
     async list<C extends keyof CredentialRequest = never>(
         teamId: number,
-        options: ListCredentialRequestsOptions<C> = {},
+        options?: ListCredentialRequestsOptions<C>,
+    ): Promise<PickColumns<CredentialRequest, C>[]>;
+
+    /**
+     * @deprecated Pass `teamId` as the first argument: `list(teamId, options?)`.
+     */
+    async list<C extends keyof CredentialRequest = never>(
+        options: ListCredentialRequestsOptions<C> & { teamId: number },
+    ): Promise<PickColumns<CredentialRequest, C>[]>;
+
+    async list<C extends keyof CredentialRequest = never>(
+        teamIdOrOptions: number | (ListCredentialRequestsOptions<C> & { teamId: number }),
+        options?: ListCredentialRequestsOptions<C>,
     ): Promise<PickColumns<CredentialRequest, C>[]> {
+        let teamId: number;
+        if (typeof teamIdOrOptions === 'number') {
+            teamId = teamIdOrOptions;
+            options ??= {} as ListCredentialRequestsOptions<C>;
+        } else {
+            ({ teamId, ...options } = teamIdOrOptions as { teamId: number } & ListCredentialRequestsOptions<C>);
+        }
+
         const response = await this.#fetch<{ requests: PickColumns<CredentialRequest, C>[] }>(
             '/credential-requests/requests',
             { query: { teamId, ...options } },

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -239,11 +239,11 @@ export class CredentialRequests {
         options?: ListCredentialRequestsOptions<C>,
     ): Promise<PickColumns<CredentialRequest, C>[]> {
         let teamId: number;
-        if (typeof teamIdOrOptions === 'number') {
-            teamId = teamIdOrOptions;
-            options ??= {} as ListCredentialRequestsOptions<C>;
-        } else {
+        if (teamIdOrOptions !== null && typeof teamIdOrOptions === 'object') {
             ({ teamId, ...options } = teamIdOrOptions);
+        } else {
+            teamId = teamIdOrOptions as number;
+            options ??= {} as ListCredentialRequestsOptions<C>;
         }
 
         const response = await this.#fetch<{ requests: PickColumns<CredentialRequest, C>[] }>(

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -81,7 +81,7 @@ export type ListCredentialRequestsOptions<C extends keyof CredentialRequest = ne
     /** Specific columns/fields to include in the response */
     cols?: C[] | ['*'];
     /** Filter by team ID */
-    teamId?: number;
+    teamId: number;
     /** Filter by user ID */
     userId?: number;
     /** Filter by Make provider ID */
@@ -222,7 +222,7 @@ export class CredentialRequests {
      * List credential requests with optional filtering and pagination
      */
     async list<C extends keyof CredentialRequest = never>(
-        options: ListCredentialRequestsOptions<C> = {},
+        options: ListCredentialRequestsOptions<C>,
     ): Promise<PickColumns<CredentialRequest, C>[]> {
         const response = await this.#fetch<{ requests: PickColumns<CredentialRequest, C>[] }>(
             '/credential-requests/requests',

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -80,8 +80,6 @@ export type GetCredentialRequestOptions<C extends keyof CredentialRequest = neve
 export type ListCredentialRequestsOptions<C extends keyof CredentialRequest = never> = {
     /** Specific columns/fields to include in the response */
     cols?: C[] | ['*'];
-    /** Filter by team ID */
-    teamId: number;
     /** Filter by user ID */
     userId?: number;
     /** Filter by Make provider ID */
@@ -221,14 +219,16 @@ export class CredentialRequests {
     /**
      * List credential requests for a given team, with optional additional filtering and pagination.
      *
-     * @param options - Query options. `teamId` is required, the API returns an error if it is omitted.
+     * @param teamId - The team to list credential requests for.
+     * @param options - Optional filters (user, provider, status, name) and pagination.
      */
     async list<C extends keyof CredentialRequest = never>(
-        options: ListCredentialRequestsOptions<C>,
+        teamId: number,
+        options: ListCredentialRequestsOptions<C> = {},
     ): Promise<PickColumns<CredentialRequest, C>[]> {
         const response = await this.#fetch<{ requests: PickColumns<CredentialRequest, C>[] }>(
             '/credential-requests/requests',
-            { query: options },
+            { query: { teamId, ...options } },
         );
         return response.requests;
     }

--- a/test/credential-requests.integration.test.ts
+++ b/test/credential-requests.integration.test.ts
@@ -54,7 +54,7 @@ describe('Integration: CredentialRequests', () => {
     });
 
     it('Should list credential requests', async () => {
-        const requests = await make.credentialRequests.list({ teamId: MAKE_TEAM });
+        const requests = await make.credentialRequests.list(MAKE_TEAM);
         expect(Array.isArray(requests)).toBe(true);
         expect(requests.some(r => r.id === requestId)).toBe(true);
     });
@@ -86,7 +86,7 @@ describe('Integration: CredentialRequests', () => {
         await make.credentialRequests.delete(requestId);
 
         // Check that request is deleted
-        const requests = await make.credentialRequests.list({ teamId: MAKE_TEAM });
+        const requests = await make.credentialRequests.list(MAKE_TEAM);
         expect(requests.some(r => r.id === requestId)).toBe(false);
     });
 
@@ -116,7 +116,7 @@ describe('Integration: CredentialRequests', () => {
         await make.credentialRequests.delete(actionRequestId);
 
         // Check that request is deleted
-        const requests = await make.credentialRequests.list({ teamId: MAKE_TEAM });
+        const requests = await make.credentialRequests.list(MAKE_TEAM);
         expect(requests.some(r => r.id === actionRequestId)).toBe(false);
     });
 
@@ -169,7 +169,7 @@ describe('Integration: CredentialRequests', () => {
     it('Should delete the credential request created with a connection', async () => {
         await make.credentialRequests.delete(connectionRequestId);
 
-        const requests = await make.credentialRequests.list({ teamId: MAKE_TEAM });
+        const requests = await make.credentialRequests.list(MAKE_TEAM);
         expect(requests.some(r => r.id === connectionRequestId)).toBe(false);
     });
 
@@ -196,7 +196,7 @@ describe('Integration: CredentialRequests', () => {
     it('Should delete the credential request created with a key', async () => {
         await make.credentialRequests.delete(keyRequestId);
 
-        const requests = await make.credentialRequests.list({ teamId: MAKE_TEAM });
+        const requests = await make.credentialRequests.list(MAKE_TEAM);
         expect(requests.some(r => r.id === keyRequestId)).toBe(false);
     });
 
@@ -232,7 +232,7 @@ describe('Integration: CredentialRequests', () => {
     it('Should delete the credential request created with both connections and keys', async () => {
         await make.credentialRequests.delete(mixedRequestId);
 
-        const requests = await make.credentialRequests.list({ teamId: MAKE_TEAM });
+        const requests = await make.credentialRequests.list(MAKE_TEAM);
         expect(requests.some(r => r.id === mixedRequestId)).toBe(false);
     });
 
@@ -256,7 +256,7 @@ describe('Integration: CredentialRequests', () => {
     it('Should delete the credential request created with nameOverride', async () => {
         await make.credentialRequests.delete(nameOverrideRequestId);
 
-        const requests = await make.credentialRequests.list({ teamId: MAKE_TEAM });
+        const requests = await make.credentialRequests.list(MAKE_TEAM);
         expect(requests.some(r => r.id === nameOverrideRequestId)).toBe(false);
     });
 });

--- a/test/credential-requests.spec.ts
+++ b/test/credential-requests.spec.ts
@@ -24,8 +24,7 @@ describe('Endpoints: CredentialRequests', () => {
             listMock,
         );
 
-        const result = await make.credentialRequests.list({
-            teamId: 123,
+        const result = await make.credentialRequests.list(123, {
             status: 'pending',
             pg: {
                 limit: 50,
@@ -41,8 +40,7 @@ describe('Endpoints: CredentialRequests', () => {
             listMock,
         );
 
-        const result = await make.credentialRequests.list({
-            teamId: 123,
+        const result = await make.credentialRequests.list(123, {
             userId: 789,
             makeProviderId: '456',
             name: 'Google Workspace Access',

--- a/test/credential-requests.spec.ts
+++ b/test/credential-requests.spec.ts
@@ -20,7 +20,7 @@ describe('Endpoints: CredentialRequests', () => {
 
     it('Should list credential requests with filters and pagination', async () => {
         mockFetch(
-            'GET https://make.local/api/v2/credential-requests/requests?teamId=123&status=pending&pg%5Blimit%5D=50',
+            'GET https://make.local/api/v2/credential-requests/requests?status=pending&pg%5Blimit%5D=50&teamId=123',
             listMock,
         );
 
@@ -44,7 +44,7 @@ describe('Endpoints: CredentialRequests', () => {
 
     it('Should list credential requests using deprecated options object signature', async () => {
         mockFetch(
-            'GET https://make.local/api/v2/credential-requests/requests?teamId=123&status=pending',
+            'GET https://make.local/api/v2/credential-requests/requests?status=pending&teamId=123',
             listMock,
         );
 
@@ -56,7 +56,7 @@ describe('Endpoints: CredentialRequests', () => {
 
     it('Should list credential requests with multiple filters', async () => {
         mockFetch(
-            'GET https://make.local/api/v2/credential-requests/requests?teamId=123&userId=789&makeProviderId=456&name=Google+Workspace+Access',
+            'GET https://make.local/api/v2/credential-requests/requests?userId=789&makeProviderId=456&name=Google+Workspace+Access&teamId=123',
             listMock,
         );
 

--- a/test/credential-requests.spec.ts
+++ b/test/credential-requests.spec.ts
@@ -34,6 +34,26 @@ describe('Endpoints: CredentialRequests', () => {
         expect(result).toStrictEqual(listMock.requests);
     });
 
+    it('Should list credential requests with teamId only', async () => {
+        mockFetch('GET https://make.local/api/v2/credential-requests/requests?teamId=123', listMock);
+
+        const result = await make.credentialRequests.list(123);
+
+        expect(result).toStrictEqual(listMock.requests);
+    });
+
+    it('Should list credential requests using deprecated options object signature', async () => {
+        mockFetch(
+            'GET https://make.local/api/v2/credential-requests/requests?teamId=123&status=pending',
+            listMock,
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const result = await make.credentialRequests.list({ teamId: 123, status: 'pending' });
+
+        expect(result).toStrictEqual(listMock.requests);
+    });
+
     it('Should list credential requests with multiple filters', async () => {
         mockFetch(
             'GET https://make.local/api/v2/credential-requests/requests?teamId=123&userId=789&makeProviderId=456&name=Google+Workspace+Access',

--- a/test/credential-requests.spec.ts
+++ b/test/credential-requests.spec.ts
@@ -18,14 +18,6 @@ const MAKE_ZONE = 'make.local';
 describe('Endpoints: CredentialRequests', () => {
     const make = new Make(MAKE_API_KEY, MAKE_ZONE);
 
-    it('Should list credential requests', async () => {
-        mockFetch('GET https://make.local/api/v2/credential-requests/requests', listMock);
-
-        const result = await make.credentialRequests.list();
-
-        expect(result).toStrictEqual(listMock.requests);
-    });
-
     it('Should list credential requests with filters and pagination', async () => {
         mockFetch(
             'GET https://make.local/api/v2/credential-requests/requests?teamId=123&status=pending&pg%5Blimit%5D=50',


### PR DESCRIPTION
This PR tightens the Credential Requests “list” API to require a teamId in order to align request construction and MCP tooling with the endpoint’s expected parameters.

