### PR TITLE
chore: refined tool types and eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default tseslint.config(
     },
     {
         // enable jest rules on test files
-        files: ['**/*.test.ts'],
+        files: ['**/*.test.ts', '**/*.spec.ts'],
         extends: [jestPlugin.configs['flat/recommended']],
         rules: {
             'jest/no-standalone-expect': ['error', { additionalTestBlockFunctions: ['itif'] }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",

--- a/src/endpoints/connections.tools.ts
+++ b/src/endpoints/connections.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../make.js';
 import type { JSONValue } from '../types.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'connections_list',
         title: 'List connections',

--- a/src/endpoints/credential-requests.tools.ts
+++ b/src/endpoints/credential-requests.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'credential-requests_list',
         title: 'List credential requests',
@@ -19,7 +20,7 @@ export const tools = [
                 teamId: { type: 'number', description: 'Filter by team ID' },
                 userId: { type: 'number', description: 'Filter by user ID' },
                 makeProviderId: {
-                    type: ['string', 'number'],
+                    oneOf: [{ type: 'string' }, { type: 'number' }],
                     description: 'Filter by Make provider ID',
                 },
                 status: { type: 'string', description: 'Filter by status' },
@@ -465,8 +466,9 @@ export const tools = [
             'For custom/SDK apps, prefix the app name with `app#` (e.g. `app#my-custom-app`).',
         category: 'credential-requests',
         scope: 'apps:read',
-        scopeId: 'appName',
-        identifier: 'appName',
+        scopeId: undefined,
+        identifier: undefined,
+        resourceId: 'appName',
         annotations: {
             readOnlyHint: true,
         },

--- a/src/endpoints/data-store-records.tools.ts
+++ b/src/endpoints/data-store-records.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../make.js';
 import type { JSONValue } from '../types.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'data-store-records_list',
         title: 'List data store records',

--- a/src/endpoints/data-stores.tools.ts
+++ b/src/endpoints/data-stores.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'data-stores_list',
         title: 'List data stores',

--- a/src/endpoints/data-structures.tools.ts
+++ b/src/endpoints/data-structures.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../make.js';
 import type { DataStructureField } from './data-structures.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'data-structures_list',
         title: 'List data structures',

--- a/src/endpoints/devices.tools.ts
+++ b/src/endpoints/devices.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'devices_list',
         title: 'List devices',

--- a/src/endpoints/enums.tools.ts
+++ b/src/endpoints/enums.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'enums_countries',
         title: 'List countries',

--- a/src/endpoints/executions.tools.ts
+++ b/src/endpoints/executions.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'executions_list',
         title: 'List executions',

--- a/src/endpoints/folders.tools.ts
+++ b/src/endpoints/folders.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'folders_list',
         title: 'List folders',

--- a/src/endpoints/functions.tools.ts
+++ b/src/endpoints/functions.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'functions_list',
         title: 'List functions',

--- a/src/endpoints/hooks.tools.ts
+++ b/src/endpoints/hooks.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../make.js';
 import type { JSONValue } from '../types.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'hooks_list',
         title: 'List webhooks/mailhooks',

--- a/src/endpoints/incomplete-executions.tools.ts
+++ b/src/endpoints/incomplete-executions.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'incomplete-executions_list',
         title: 'List incomplete executions',

--- a/src/endpoints/keys.tools.ts
+++ b/src/endpoints/keys.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../make.js';
 import type { JSONValue } from '../types.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'keys_list',
         title: 'List keys',

--- a/src/endpoints/organizations.tools.ts
+++ b/src/endpoints/organizations.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'organizations_list',
         title: 'List organizations',

--- a/src/endpoints/organizations.ts
+++ b/src/endpoints/organizations.ts
@@ -1,4 +1,4 @@
-import type { FetchFunction, Pagination, PickColumns } from '../types.js';
+import type { FetchFunction, JSONValue, Pagination, PickColumns } from '../types.js';
 
 /**
  * Represents an organization in Make.
@@ -131,7 +131,7 @@ export type Organization = {
     /** Unused transfer */
     unusedTransfer: string;
     /** Organization features */
-    features: Record<string, unknown>;
+    features: Record<string, JSONValue>;
     /** External ID for white label instances */
     externalId: string;
     /** Number of active apps */

--- a/src/endpoints/public-templates.tools.ts
+++ b/src/endpoints/public-templates.tools.ts
@@ -8,6 +8,8 @@ export const tools = [
             'Search and list public (approved) templates available for anyone. Supports name-based search for template discovery. Results are sorted by usage by default.',
         category: 'public-templates',
         scope: 'templates:read',
+        scopeId: undefined,
+        identifier: undefined,
         annotations: {
             readOnlyHint: true,
         },
@@ -38,8 +40,8 @@ export const tools = [
             'Get details of a public template by its URL slug (e.g. "12289-add-webhook-data-to-a-google-sheet"). Use this for templates discovered via public-templates_list.',
         category: 'public-templates',
         scope: 'templates:read',
-        scopeId: 'templateUrl',
-        identifier: 'templateUrl',
+        scopeId: undefined,
+        identifier: undefined,
         resourceId: 'templateUrl',
         annotations: {
             readOnlyHint: true,
@@ -67,8 +69,8 @@ export const tools = [
             'Get the full blueprint of a public template including scenario flow, controller configuration, scheduling, and metadata. Use this for templates discovered via public-templates_list.',
         category: 'public-templates',
         scope: 'templates:read',
-        scopeId: 'templateUrl',
-        identifier: 'templateUrl',
+        scopeId: undefined,
+        identifier: undefined,
         resourceId: 'templateUrl',
         annotations: {
             readOnlyHint: true,

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -2,8 +2,9 @@ import type { Blueprint, DataStructureField } from '../index.js';
 import type { Make } from '../make.js';
 import type { JSONValue } from '../types.js';
 import type { Scheduling } from './scenarios.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'scenarios_list',
         title: 'List scenarios',

--- a/src/endpoints/scenarios.ts
+++ b/src/endpoints/scenarios.ts
@@ -58,7 +58,7 @@ export type Scenario = {
     /** Data transfer consumed in the current period */
     transfer: number;
     /** Custom properties defined for the scenario */
-    customProperties?: Record<string, unknown>;
+    customProperties?: Record<string, JSONValue>;
 };
 
 export type Scheduling = {
@@ -168,7 +168,7 @@ export type RunScenarioResponse = {
     /** Status of the scenario execution when run in responsive mode (1 = successful, 2 = successful with warnings, 3 = failed) */
     status?: 1 | 2 | 3;
     /** Output data from the scenario execution (when run in responsive mode) */
-    outputs: unknown;
+    outputs?: JSONValue;
 };
 
 /**

--- a/src/endpoints/sdk/apps.tools.ts
+++ b/src/endpoints/sdk/apps.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../../make.js';
 import type { JSONValue } from '../../types.js';
+import type { MakeTool } from '../../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'sdk-apps_list',
         title: 'List SDK apps',

--- a/src/endpoints/sdk/apps.ts
+++ b/src/endpoints/sdk/apps.ts
@@ -32,7 +32,7 @@ export type SDKApp = {
     /** The manifest version */
     manifestVersion: number;
     /** Stack of changes made to the app */
-    changes?: unknown[];
+    changes?: Record<string, JSONValue>[];
 };
 
 /**

--- a/src/endpoints/sdk/connections.tools.ts
+++ b/src/endpoints/sdk/connections.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../../make.js';
 import type { JSONValue } from '../../types.js';
+import type { MakeTool } from '../../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'sdk-connections_list',
         title: 'List SDK connections',

--- a/src/endpoints/sdk/functions.tools.ts
+++ b/src/endpoints/sdk/functions.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../../make.js';
+import type { MakeTool } from '../../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'sdk-functions_list',
         title: 'List SDK functions',

--- a/src/endpoints/sdk/modules.tools.ts
+++ b/src/endpoints/sdk/modules.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../../make.js';
+import type { MakeTool } from '../../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'sdk-modules_list',
         title: 'List SDK modules',

--- a/src/endpoints/sdk/rpcs.tools.ts
+++ b/src/endpoints/sdk/rpcs.tools.ts
@@ -1,7 +1,8 @@
 import type { Make } from '../../make.js';
 import type { JSONValue } from '../../types.js';
+import type { MakeTool } from '../../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'sdk-rpcs_list',
         title: 'List SDK RPCs',

--- a/src/endpoints/sdk/rpcs.ts
+++ b/src/endpoints/sdk/rpcs.ts
@@ -148,7 +148,7 @@ export class SDKRPCs {
      * Test an RPC with provided data and schema
      * @returns The test result
      */
-    async test(appName: string, appVersion: number, rpcName: string, body: TestSDKRPCBody): Promise<unknown> {
+    async test(appName: string, appVersion: number, rpcName: string, body: TestSDKRPCBody): Promise<JSONValue> {
         return await this.#fetch(`/sdk/apps/${appName}/${appVersion}/rpcs/${rpcName}`, {
             method: 'POST',
             body,

--- a/src/endpoints/sdk/webhooks.tools.ts
+++ b/src/endpoints/sdk/webhooks.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../../make.js';
+import type { MakeTool } from '../../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'sdk-webhooks_list',
         title: 'List SDK webhooks',

--- a/src/endpoints/teams.tools.ts
+++ b/src/endpoints/teams.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'teams_list',
         title: 'List teams',

--- a/src/endpoints/users.tools.ts
+++ b/src/endpoints/users.tools.ts
@@ -1,6 +1,7 @@
 import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
 
-export const tools = [
+export const tools: MakeTool[] = [
     {
         name: 'users_me',
         title: 'Get current user',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -39,6 +39,8 @@ export type JSONSchema = {
     type?: 'object' | 'string' | 'number' | 'boolean' | 'array' | 'null';
     /** Properties definition for object types */
     properties?: Record<string, JSONSchema>;
+    /** Schemas for properties whose names match a regex pattern (object types) */
+    patternProperties?: Record<string, JSONSchema>;
     /** Required property names for object types */
     required?: string[];
     /** Items schema for array types */
@@ -177,7 +179,7 @@ export type MakeTool = {
      * @param args The input arguments matching the inputSchema
      * @returns Promise resolving to the operation result
      */
-    execute: (make: Make, args?: Record<string, JSONValue>) => Promise<JSONValue>;
+    execute(make: Make, args: Record<string, JSONValue>): Promise<JSONValue>;
 };
 
 /**

--- a/test/mcp.spec.ts
+++ b/test/mcp.spec.ts
@@ -37,12 +37,12 @@ describe('MCP Tools', () => {
             expect(tool.title.length).toBeGreaterThan(0);
             expect(tool.description.length).toBeGreaterThan(0);
             expect(tool.category.length).toBeGreaterThan(0);
+        });
 
-            // Scope is optional, but if present should be a string
-            if (tool.scope !== undefined) {
-                expect(typeof tool.scope).toBe('string');
-                expect(tool.scope.length).toBeGreaterThan(0);
-            }
+        // Scope is optional, but if present should be a non-empty string
+        MakeTools.filter(tool => tool.scope !== undefined).forEach(tool => {
+            expect(typeof tool.scope).toBe('string');
+            expect(tool.scope!.length).toBeGreaterThan(0);
         });
     });
 
@@ -64,7 +64,7 @@ describe('MCP Tools', () => {
                 seen.add(name);
             });
 
-            fail(`Duplicate tool names found: ${duplicates.join(', ')}`);
+            throw new Error(`Duplicate tool names found: ${duplicates.join(', ')}`);
         }
     });
 
@@ -103,11 +103,11 @@ describe('MCP Tools', () => {
             // Categories should use dot notation for hierarchy
             const categoryPattern = /^[a-z][a-z.-]*[a-z]$/;
             expect(tool.category).toMatch(categoryPattern);
+        });
 
-            // SDK categories should start with "sdk."
-            if (tool.name.startsWith('sdk_')) {
-                expect(tool.category).toMatch(/^sdk\./);
-            }
+        // SDK categories should start with "sdk."
+        MakeTools.filter(tool => tool.name.startsWith('sdk_')).forEach(tool => {
+            expect(tool.category).toMatch(/^sdk\./);
         });
     });
 


### PR DESCRIPTION
Tightens types across the harness-agnostic tool definitions and irons out a few small ESLint / test issues that fell out of recent refactors.