### PR TITLE
fix(sdk): centicredits in executions list

### DIFF
--- a/src/endpoints/executions.ts
+++ b/src/endpoints/executions.ts
@@ -30,6 +30,8 @@ export type Execution = {
     authorId: number | null;
     /** Whether the execution was run instantly */
     instant: boolean;
+    /** ISO 8601 timestamp of when the execution occurred */
+    timestamp: string;
 };
 
 /**

--- a/src/endpoints/executions.ts
+++ b/src/endpoints/executions.ts
@@ -16,6 +16,8 @@ export type Execution = {
     duration: number;
     /** Number of operations consumed by the execution */
     operations: number;
+    /** Credits consumed by the execution, in centicredits (hundredths of a credit) */
+    centicredits: number;
     /** Amount of data transfer consumed by the execution */
     transfer: number;
     /** ID of the organization the execution belongs to */

--- a/test/mocks/executions/get.json
+++ b/test/mocks/executions/get.json
@@ -3,6 +3,7 @@
         "imtId": "1632398122946_scenario.5.manual.cc1c49323b344687a324888762206003",
         "duration": 5611,
         "operations": 2,
+        "centicredits": 200,
         "transfer": 5,
         "organizationId": 5,
         "teamId": 16,

--- a/test/mocks/executions/list.json
+++ b/test/mocks/executions/list.json
@@ -4,6 +4,7 @@
             "imtId": "1632371744497_scenario.1229.auto.da518adcd14b4b64ac6358823ccb80ca",
             "duration": 19979,
             "operations": 10,
+            "centicredits": 1000,
             "transfer": 3942,
             "organizationId": 21,
             "teamId": 27,


### PR DESCRIPTION
Document centicredits field in the types and test assets. The field is already being delivered, was not documented.

https://make.atlassian.net/browse/WM-4172