### PR TITLE
feat(cred-req/endpoints): add support for requesting credentials by endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",

--- a/src/endpoints/credential-requests.tools.ts
+++ b/src/endpoints/credential-requests.tools.ts
@@ -1,5 +1,6 @@
 import type { Make } from '../make.js';
 import type { MakeTool } from '../tools.js';
+import type { CredentialSelection } from './credential-requests.js';
 
 export const tools: MakeTool[] = [
     {
@@ -198,7 +199,7 @@ export const tools: MakeTool[] = [
                                 type: 'array',
                                 description:
                                     'Array of module IDs to request from the user, for example: ["WatchDirectMessages", "WatchFiles"]. ' +
-                                    'Use ["*"] to select all modules for the given application. Either appModules or appEndpoints must be specified.',
+                                    'Use ["*"] to select all modules for the given application. At least one of appModules or appEndpoints must be specified (both may be provided together).',
                                 minItems: 1,
                                 items: { type: 'string' },
                             },
@@ -206,7 +207,7 @@ export const tools: MakeTool[] = [
                                 type: 'array',
                                 description:
                                     'Array of Endpoint Names that the credential will be used to access, for example: ["GetUser", "ListFiles"]. ' +
-                                    'Use ["*"] to select all endpoints for the given application. Either appModules or appEndpoints must be specified.',
+                                    'Use ["*"] to select all endpoints for the given application. At least one of appModules or appEndpoints must be specified (both may be provided together).',
                                 minItems: 1,
                                 items: { type: 'string' },
                             },
@@ -244,14 +245,7 @@ export const tools: MakeTool[] = [
                 name?: string;
                 description?: string;
                 teamId: number;
-                credentials: {
-                    appName: string;
-                    appModules?: string[];
-                    appEndpoints?: string[];
-                    appVersion?: number;
-                    nameOverride?: string;
-                    description?: string;
-                }[];
+                credentials: CredentialSelection[];
             },
         ) => {
             return await make.credentialRequests.createAction(args);

--- a/src/endpoints/credential-requests.tools.ts
+++ b/src/endpoints/credential-requests.tools.ts
@@ -198,7 +198,15 @@ export const tools: MakeTool[] = [
                                 type: 'array',
                                 description:
                                     'Array of module IDs to request from the user, for example: ["WatchDirectMessages", "WatchFiles"]. ' +
-                                    'Use ["*"] to select all modules for the given application.',
+                                    'Use ["*"] to select all modules for the given application. Either appModules or appEndpoints must be specified.',
+                                minItems: 1,
+                                items: { type: 'string' },
+                            },
+                            appEndpoints: {
+                                type: 'array',
+                                description:
+                                    'Array of Endpoint Names that the credential will be used to access, for example: ["GetUser", "ListFiles"]. ' +
+                                    'Use ["*"] to select all endpoints for the given application. Either appModules or appEndpoints must be specified.',
                                 minItems: 1,
                                 items: { type: 'string' },
                             },
@@ -217,7 +225,7 @@ export const tools: MakeTool[] = [
                                 description: 'Description for this credential to be displayed in the Request view.',
                             },
                         },
-                        required: ['appName', 'appModules'],
+                        required: ['appName'],
                     },
                 },
             },
@@ -238,7 +246,8 @@ export const tools: MakeTool[] = [
                 teamId: number;
                 credentials: {
                     appName: string;
-                    appModules: string[];
+                    appModules?: string[];
+                    appEndpoints?: string[];
                     appVersion?: number;
                     nameOverride?: string;
                     description?: string;

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -116,8 +116,10 @@ export type CreateCredentialRequestBody = {
 export type CredentialSelection = {
     /** Name of the application to request credentials for */
     appName: string;
-    /** Array of module IDs to include. Use ["*"] to select all modules with credentials. */
-    appModules: string[];
+    /** Array of module IDs to include. Use ["*"] to select all modules with credentials. Either Modules or Endpoints have to be specified */
+    appModules?: string[];
+    /** Array of Endpoint Names that the credential will be used to access. Use ["*"] to select all endpoints. Either Modules or Endpoints have to be specified */
+    appEndpoints?: string[];
     /** Version of the application. Defaults to the latest available version if not provided. */
     appVersion?: number;
     /** Optional name override for the credential when created in the platform */

--- a/src/endpoints/credential-requests.ts
+++ b/src/endpoints/credential-requests.ts
@@ -110,16 +110,9 @@ export type CreateCredentialRequestBody = {
     provider: Record<string, JSONValue>;
 };
 
-/**
- * Represents an app/module selection to derive credentials from.
- */
-export type CredentialSelection = {
+type CredentialSelectionBase = {
     /** Name of the application to request credentials for */
     appName: string;
-    /** Array of module IDs to include. Use ["*"] to select all modules with credentials. Either Modules or Endpoints have to be specified */
-    appModules?: string[];
-    /** Array of Endpoint Names that the credential will be used to access. Use ["*"] to select all endpoints. Either Modules or Endpoints have to be specified */
-    appEndpoints?: string[];
     /** Version of the application. Defaults to the latest available version if not provided. */
     appVersion?: number;
     /** Optional name override for the credential when created in the platform */
@@ -127,6 +120,26 @@ export type CredentialSelection = {
     /** Description for this credential to be displayed in the Request view */
     description?: string;
 };
+
+/**
+ * Represents an app/module selection to derive credentials from.
+ * At least one of `appModules` or `appEndpoints` must be specified (both may be provided together).
+ */
+export type CredentialSelection = CredentialSelectionBase &
+    (
+        | {
+              /** Array of module IDs to include. Use ["*"] to select all modules with credentials. */
+              appModules: string[];
+              /** Array of Endpoint Names that the credential will be used to access. Use ["*"] to select all endpoints. */
+              appEndpoints?: string[];
+          }
+        | {
+              /** Array of module IDs to include. Use ["*"] to select all modules with credentials. */
+              appModules?: string[];
+              /** Array of Endpoint Names that the credential will be used to access. Use ["*"] to select all endpoints. */
+              appEndpoints: string[];
+          }
+    );
 
 /**
  * Body for creating a credential action

--- a/test/credential-requests.integration.test.ts
+++ b/test/credential-requests.integration.test.ts
@@ -120,6 +120,24 @@ describe('Integration: CredentialRequests', () => {
         expect(requests.some(r => r.id === actionRequestId)).toBe(false);
     });
 
+    it('Should create a credential action using appEndpoints', async () => {
+        const action = await make.credentialRequests.createAction({
+            teamId: MAKE_TEAM,
+            credentials: [
+                {
+                    appName: 'http',
+                    appEndpoints: ['*'],
+                    appVersion: 3,
+                },
+            ],
+        });
+        expect(action.request.id).toBeDefined();
+        expect(action.publicUri).toBeDefined();
+        expect(action.request.teamId).toBe(MAKE_TEAM);
+
+        await make.credentialRequests.delete(action.request.id);
+    });
+
     it('Should create a credential action with name and description', async () => {
         const action = await make.credentialRequests.createAction({
             teamId: MAKE_TEAM,

--- a/test/credential-requests.spec.ts
+++ b/test/credential-requests.spec.ts
@@ -213,6 +213,40 @@ describe('Endpoints: CredentialRequests', () => {
         });
     });
 
+    it('Should create a credential action with appEndpoints', async () => {
+        const body = {
+            teamId: 123,
+            credentials: [
+                {
+                    appName: 'http',
+                    appEndpoints: ['GetUser', 'ListFiles'],
+                    appVersion: 3,
+                },
+            ],
+        };
+
+        mockFetch('POST https://make.local/api/v2/credential-requests/actions/create', createActionMock, req => {
+            expect(req.body).toStrictEqual(body);
+            expect(req.headers.get('content-type')).toBe('application/json');
+        });
+
+        const result = await make.credentialRequests.createAction({
+            teamId: 123,
+            credentials: [
+                {
+                    appName: 'http',
+                    appEndpoints: ['GetUser', 'ListFiles'],
+                    appVersion: 3,
+                },
+            ],
+        });
+
+        expect(result).toStrictEqual({
+            request: createActionMock.request,
+            publicUri: createActionMock.publicUri,
+        });
+    });
+
     it('Should create a credential request by connection/key types', async () => {
         const body = {
             teamId: 123,


### PR DESCRIPTION
I'm adding possibility to start sending `appEndpoints` as input to the Credential Requests when creating them "by targets", similarly as we do it with Modules already. Thanks to this, the Scope Inference is done by Make, and caller doesn't need to bother -- simplifies life for the Agents.