### PR TITLE
chore(credential-requests): shorten tool name past MCP host's 48-char crop

### DIFF
--- a/src/endpoints/credential-requests.tools.ts
+++ b/src/endpoints/credential-requests.tools.ts
@@ -461,7 +461,7 @@ export const tools: MakeTool[] = [
         },
     },
     {
-        name: 'credential-requests_list-app-modules-with-credentials',
+        name: 'credential-requests_list-app-modules-with-creds',
         title: 'List app modules with credentials',
         description:
             'List all modules of a given Make app (and version) that require credentials, along with the required credential type and OAuth scopes. ' +

--- a/test/mcp.spec.ts
+++ b/test/mcp.spec.ts
@@ -68,6 +68,18 @@ describe('MCP Tools', () => {
         }
     });
 
+    it('Should not have tool names longer than the MCP host guaranteed length', () => {
+        // make-mcp-server-host's ToolNameCropMinThreshold (lib/validations/mcp-tools.schema.ts) is 48.
+        // Names longer than that are silently truncated on registration (only a console.warn),
+        // producing a mangled tool name exposed to MCP clients (e.g. cut off mid-word).
+        const TOOL_NAME_CROP_MIN_THRESHOLD = 48;
+        const tooLong = MakeTools.filter(tool => tool.name.length > TOOL_NAME_CROP_MIN_THRESHOLD).map(
+            tool => `${tool.name} (${tool.name.length} chars)`,
+        );
+
+        expect(tooLong).toEqual([]);
+    });
+
     it('Should have tools from SDK endpoints', () => {
         const sdkTools = MakeTools.filter(tool => tool.category.startsWith('sdk-'));
         expect(sdkTools.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Finding
type: doc-gap (name-quality)
surface(s): mcp, sdk (likely cli too — not verified, repo not available for this pass)

`credential-requests_list-app-modules-with-credentials` (defined in this repo) is 53 characters.
make-mcp-server-host's `ToolMatcher` decorator silently crops any static tool name longer than
`ToolNameCropMinThreshold` (48, `lib/validations/mcp-tools.schema.ts:10`) at registration time —
only a `console.warn` fires, no build/deploy failure — and the cropped string becomes the tool's
canonical registered/advertised name.

Confirmed on `make-mcp-server-host` `origin/master`: the tool is actually registered and shown to
MCP clients as `credential-requests_list-app-modules-with-creden`, truncated mid-word
(`test/integration/modules/__snapshots__/management.common.spec.ts.snap:1584`). It's still callable
— MCP clients discover tool names live via `tools/list` — so this isn't an outage. The defect is a
mangled, unprofessional-looking name shown to the LLM, plus a drift between what this SDK's source
(and `make-cli`, and any tooling that reads `MakeTools` directly) shows versus what MCP actually
exposes.

## Evidence
- Lens: agent-interfaces-self-improve, static drift/description-lint pass over MCP tool names,
  focused on the MCP surface.
- `make-typescript-sdk/src/endpoints/credential-requests.tools.ts:461` — literal 53-char name.
- `make-mcp-server-host/lib/validations/mcp-tools.schema.ts:10` — `ToolNameCropMinThreshold = 48`.
- `make-mcp-server-host/lib/libs/make-mcp-server/conversation-module.ts:411-426` — crop logic:
  `const name = pattern.slice(0, ToolNameCropMinThreshold)`, warns but never throws, and that
  cropped `name` is what's stored as the tool's canonical identity.
- `make-mcp-server-host/test/integration/modules/__snapshots__/management.common.spec.ts.snap:1584`
  (read from `origin/master`) — proves the live/tested advertised name is
  `credential-requests_list-app-modules-with-creden`.

## Mapping
- Both sides of the drift:
  - SDK source (this repo): `credential-requests_list-app-modules-with-credentials` (53 chars)
  - MCP-advertised (host, confirmed via test snapshot): `credential-requests_list-app-modules-with-creden` (48 chars, truncated mid-word)
- Fix routing: per make-ai-test-harness `references/repo-map.md` routing table, a public-API tool
  name/description defect is fixed in `make-typescript-sdk src/endpoints/{entity}.tools.ts` — this repo.

## Fix / proposal
Renamed the tool to `credential-requests_list-app-modules-with-creds` (47 chars, under the
threshold, no truncation). The underlying SDK client method
(`credentialRequests.listAppModulesWithCredentials`) is unchanged — only the MCP-facing `name`
field moved.

Added a regression test in `test/mcp.spec.ts` asserting no `MakeTools` entry exceeds the host's
48-char threshold, since this repo has no visibility into that host-side constant today and nothing
previously caught the crop. (Threshold is inlined with a comment pointing at its source of truth,
since this repo doesn't depend on `make-mcp-server-host`.)

Alternatives considered: a shorter name dropping "with-credentials" entirely (e.g.
`credential-requests_list-app-modules`, 37 chars) would read more consistently with how terse
sibling names in this file already are — happy to switch if preferred on review.

**Delivery chain:** this fix alone doesn't reach production. It needs an `@makehq/sdk` npm
release, then `make-mcp-server-host` bumping its pinned SDK version and deploying. There is no
GrowthBook fast-mitigation path for a tool *name* change (only descriptions are override-able via
`mcp-tool-description_{toolName}`), so until the host redeploys, the live tool stays exposed under
the truncated `...creden` name.

## Validation
- New regression test fails pre-fix (temporarily reverted the source change, kept only the test):
  `tooLong` = `["credential-requests_list-app-modules-with-credentials (53 chars)"]`
- Passes post-fix: 17/17 tests in `test/mcp.spec.ts`
- Full suite: 34 test suites, 259/259 tests passing; `npm run lint` clean; `npm run build` clean

Re-run commands (from repo root):
```
npx jest --testMatch "**/test/mcp.spec.ts" -t "guaranteed length" --coverage=false
npm test
npm run lint
npm run build
```

🤖 Generated with [agent-interfaces-self-improve](https://github.com/integromat/make-ai-test-harness/blob/master/.claude/skills/agent-interfaces-self-improve/SKILL.md), a self-improving audit loop over Make's agent-facing surfaces.