### PR TITLE
fix(scenarios): clarify scenarios_run doesn't simulate real webhook delivery

### DIFF
--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -242,7 +242,8 @@ export const tools: MakeTool[] = [
     {
         name: 'scenarios_run',
         title: 'Run scenario',
-        description: 'Execute a scenario with optional input data.',
+        description:
+            'Execute a scenario with optional input data. For a webhook-triggered scenario, this runs it on demand and does not simulate an actual inbound HTTP request to the webhook URL — to verify what a real external caller receives, send a request to the webhook URL itself.',
         category: 'scenarios',
         scope: 'scenarios:run',
         scopeId: 'scenarioId',

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -243,7 +243,7 @@ export const tools: MakeTool[] = [
         name: 'scenarios_run',
         title: 'Run scenario',
         description:
-            'Execute a scenario with optional input data. For a webhook-triggered scenario, this runs it on demand and does not simulate an actual inbound HTTP request to the webhook URL — to verify what a real external caller receives, send a request to the webhook URL itself.',
+            "Execute a scenario with optional input data. For a webhook-triggered scenario, treat both this call's input and output as unreliable: `data` is injected directly as the trigger's output bundle, bypassing the webhook's real request parsing, and the scenario's declared output may not be returned here at all even on success. To verify a webhook-triggered scenario, send a real request to its webhook URL instead of relying on this tool.",
         category: 'scenarios',
         scope: 'scenarios:run',
         scopeId: 'scenarioId',

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -243,7 +243,7 @@ export const tools: MakeTool[] = [
         name: 'scenarios_run',
         title: 'Run scenario',
         description:
-            "Execute a scenario with optional input data. For a webhook-triggered scenario, treat both this call's input and output as unreliable: `data` is injected directly as the trigger's output bundle, bypassing the webhook's real request parsing, and the scenario's declared output may not be returned here at all even on success. To verify a webhook-triggered scenario, send a real request to its webhook URL instead of relying on this tool.",
+            "Execute a scenario with optional input data. For a webhook-triggered scenario, treat both this call's input and output as unavailable: `data` is injected directly as the trigger's output bundle, bypassing the webhook's real request parsing, and the scenario's declared output is not returned here, even on success. To verify a webhook-triggered scenario, send a real request to its webhook URL instead of relying on this tool.",
         category: 'scenarios',
         scope: 'scenarios:run',
         scopeId: 'scenarioId',


### PR DESCRIPTION
## Summary
`scenarios_run`'s description didn't warn that for a webhook-triggered scenario it exercises an on-demand run, not the actual HTTP-triggered path. Follow-up investigation sharpened the caveat: re-inspecting the source conversation's raw tool payloads showed the gap covers both directions, not just delivery simulation —

- **Input**: `data` is injected directly as the trigger module's output bundle, bypassing the webhook's real request parsing (JSON-body/query-string merging, header/method capture, data-structure validation).
- **Output**: the scenario's declared output can be absent from the `scenarios_run` response even on a genuinely clean, fully-billed run with no module errors — contrast a later on-demand (non-webhook) scenario in the same session, whose `scenarios_run` result *did* include an `outputs` object.

An agent had trusted `SUCCESS` + no visible error as proof a webhook-triggered scenario worked end-to-end, then had to leave the Make tool surface entirely and curl the webhook URL directly to discover a real caller saw something different.

## Evidence
Same source conversation as the paired make-skills PR (integromat/make-skills#38) — see that PR for the full transcript-analysis context and the newly-added skill guidance (prefer non-webhook triggers by default; verify webhook scenarios via the real URL; guard final output modules with `builtin:ThrowError`).

## Mapping
`src/endpoints/scenarios.tools.ts:243-246`

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 34/34 suites, 259/259 tests green
- No snapshot/test pins the description text (checked `test/mcp.spec.ts`, the only spec touching `MakeTools` metadata)

https://make.atlassian.net/browse/WM-4172