### PR TITLE
fix(tools): make readOnlyHint/destructiveHint/openWorldHint explicit on every tool

### DIFF
--- a/src/endpoints/connected-systems.tools.ts
+++ b/src/endpoints/connected-systems.tools.ts
@@ -14,6 +14,8 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -44,6 +46,8 @@ export const tools: MakeTool[] = [
         resourceId: 'connectedSystemId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -73,8 +77,10 @@ export const tools: MakeTool[] = [
         scopeId: 'organizationId',
         identifier: 'organizationId',
         annotations: {
-            idempotentHint: false,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -127,8 +133,10 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         resourceId: 'connectedSystemId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -182,8 +190,10 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         resourceId: 'connectedSystemId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
             idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/connections.tools.ts
+++ b/src/endpoints/connections.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -53,6 +55,8 @@ export const tools: MakeTool[] = [
         resourceId: 'connectionId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -75,8 +79,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -118,8 +124,10 @@ export const tools: MakeTool[] = [
         identifier: 'connectionId',
         resourceId: 'connectionId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -154,8 +162,10 @@ export const tools: MakeTool[] = [
         identifier: 'connectionId',
         resourceId: 'connectionId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: true,
         },
         inputSchema: {
             type: 'object',
@@ -181,7 +191,9 @@ export const tools: MakeTool[] = [
         identifier: 'connectionId',
         resourceId: 'connectionId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/credential-requests.tools.ts
+++ b/src/endpoints/credential-requests.tools.ts
@@ -14,6 +14,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -60,6 +62,8 @@ export const tools: MakeTool[] = [
         resourceId: 'requestId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -85,7 +89,9 @@ export const tools: MakeTool[] = [
         identifier: 'requestId',
         resourceId: 'requestId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -113,8 +119,10 @@ export const tools: MakeTool[] = [
         identifier: 'credentialId',
         resourceId: 'credentialId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -142,8 +150,10 @@ export const tools: MakeTool[] = [
         identifier: 'credentialId',
         resourceId: 'credentialId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -168,8 +178,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -264,8 +276,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -420,8 +434,10 @@ export const tools: MakeTool[] = [
         identifier: 'connectionId',
         resourceId: 'connectionId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -474,6 +490,8 @@ export const tools: MakeTool[] = [
         resourceId: 'appName',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/data-store-records.tools.ts
+++ b/src/endpoints/data-store-records.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: 'dataStoreId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,8 +38,10 @@ export const tools: MakeTool[] = [
         scopeId: 'dataStoreId',
         identifier: 'dataStoreId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -72,8 +76,10 @@ export const tools: MakeTool[] = [
         identifier: 'dataStoreId',
         resourceId: 'key',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -99,8 +105,10 @@ export const tools: MakeTool[] = [
         identifier: 'dataStoreId',
         resourceId: 'key',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -131,7 +139,9 @@ export const tools: MakeTool[] = [
         scopeId: 'dataStoreId',
         identifier: 'dataStoreId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/data-stores.tools.ts
+++ b/src/endpoints/data-stores.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,6 +38,8 @@ export const tools: MakeTool[] = [
         resourceId: 'dataStoreId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -58,8 +62,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -92,8 +98,10 @@ export const tools: MakeTool[] = [
         identifier: 'dataStoreId',
         resourceId: 'dataStoreId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -124,7 +132,9 @@ export const tools: MakeTool[] = [
         identifier: 'dataStoreId',
         resourceId: 'dataStoreId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/data-structures.tools.ts
+++ b/src/endpoints/data-structures.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -37,6 +39,8 @@ export const tools: MakeTool[] = [
         resourceId: 'dataStructureId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -59,8 +63,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -114,8 +120,10 @@ export const tools: MakeTool[] = [
         identifier: 'dataStructureId',
         resourceId: 'dataStructureId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -161,7 +169,9 @@ export const tools: MakeTool[] = [
         identifier: 'dataStructureId',
         resourceId: 'dataStructureId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/devices.tools.ts
+++ b/src/endpoints/devices.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/enums.tools.ts
+++ b/src/endpoints/enums.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -32,6 +34,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -52,6 +56,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -73,6 +79,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/executions.tools.ts
+++ b/src/endpoints/executions.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -40,6 +42,8 @@ export const tools: MakeTool[] = [
         resourceId: 'executionId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -65,6 +69,8 @@ export const tools: MakeTool[] = [
         resourceId: 'executionId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -89,6 +95,8 @@ export const tools: MakeTool[] = [
         identifier: 'incompleteExecutionId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -118,6 +126,8 @@ export const tools: MakeTool[] = [
         resourceId: 'executionId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/folders.tools.ts
+++ b/src/endpoints/folders.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -34,8 +36,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -60,8 +64,10 @@ export const tools: MakeTool[] = [
         identifier: 'folderId',
         resourceId: 'folderId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -87,7 +93,9 @@ export const tools: MakeTool[] = [
         identifier: 'folderId',
         resourceId: 'folderId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/functions.tools.ts
+++ b/src/endpoints/functions.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,6 +38,8 @@ export const tools: MakeTool[] = [
         resourceId: 'functionId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -58,8 +62,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -97,8 +103,10 @@ export const tools: MakeTool[] = [
         identifier: 'functionId',
         resourceId: 'functionId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -135,7 +143,9 @@ export const tools: MakeTool[] = [
         identifier: 'functionId',
         resourceId: 'functionId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -160,6 +170,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/hooks.tools.ts
+++ b/src/endpoints/hooks.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -37,6 +39,8 @@ export const tools: MakeTool[] = [
         resourceId: 'hookId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -59,8 +63,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -98,8 +104,10 @@ export const tools: MakeTool[] = [
         identifier: 'hookId',
         resourceId: 'hookId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -125,7 +133,9 @@ export const tools: MakeTool[] = [
         identifier: 'hookId',
         resourceId: 'hookId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/incomplete-executions.tools.ts
+++ b/src/endpoints/incomplete-executions.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,6 +38,8 @@ export const tools: MakeTool[] = [
         resourceId: 'incompleteExecutionId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/keys.tools.ts
+++ b/src/endpoints/keys.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -37,6 +39,8 @@ export const tools: MakeTool[] = [
         resourceId: 'keyId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -59,8 +63,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -97,8 +103,10 @@ export const tools: MakeTool[] = [
         identifier: 'keyId',
         resourceId: 'keyId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -126,7 +134,9 @@ export const tools: MakeTool[] = [
         identifier: 'keyId',
         resourceId: 'keyId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/on-prem-agents.tools.ts
+++ b/src/endpoints/on-prem-agents.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -37,6 +39,8 @@ export const tools: MakeTool[] = [
         resourceId: 'agentId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -61,8 +65,10 @@ export const tools: MakeTool[] = [
         scopeId: 'organizationId',
         identifier: 'organizationId',
         annotations: {
-            idempotentHint: false,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -87,8 +93,10 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         resourceId: 'agentId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -114,8 +122,10 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         resourceId: 'agentId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
             idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -142,6 +152,8 @@ export const tools: MakeTool[] = [
         resourceId: 'agentId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/organizations.tools.ts
+++ b/src/endpoints/organizations.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -33,6 +35,8 @@ export const tools: MakeTool[] = [
         resourceId: 'organizationId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -55,8 +59,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -86,8 +92,10 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         resourceId: 'organizationId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -123,7 +131,9 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         resourceId: 'organizationId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/public-templates.tools.ts
+++ b/src/endpoints/public-templates.tools.ts
@@ -12,6 +12,8 @@ export const tools = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -45,6 +47,8 @@ export const tools = [
         resourceId: 'templateUrl',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -74,6 +78,8 @@ export const tools = [
         resourceId: 'templateUrl',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -15,6 +15,8 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -39,6 +41,8 @@ export const tools: MakeTool[] = [
         resourceId: 'scenarioId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -67,8 +71,10 @@ export const tools: MakeTool[] = [
         scopeId: 'teamId',
         identifier: 'teamId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -118,8 +124,10 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         resourceId: 'scenarioId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -170,7 +178,9 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         resourceId: 'scenarioId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -195,8 +205,10 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         resourceId: 'scenarioId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -222,8 +234,10 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         resourceId: 'scenarioId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -249,7 +263,9 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         resourceId: 'scenarioId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: true,
         },
         inputSchema: {
             type: 'object',
@@ -281,6 +297,8 @@ export const tools: MakeTool[] = [
         resourceId: 'scenarioId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -304,8 +322,10 @@ export const tools: MakeTool[] = [
         identifier: 'scenarioId',
         resourceId: 'scenarioId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/sdk/apps.tools.ts
+++ b/src/endpoints/sdk/apps.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -33,6 +35,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -56,8 +60,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -112,8 +118,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -160,7 +168,9 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -186,6 +196,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -217,8 +229,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -258,6 +272,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -281,8 +297,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -309,6 +327,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -332,8 +352,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -360,6 +382,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -384,7 +408,12 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         identifier: undefined,
-        annotations: { idempotentHint: true, destructiveHint: false },
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
         inputSchema: {
             type: 'object',
             properties: {
@@ -407,7 +436,12 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         identifier: undefined,
-        annotations: { idempotentHint: true, destructiveHint: false },
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
         inputSchema: {
             type: 'object',
             properties: {
@@ -431,8 +465,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/sdk/connections.tools.ts
+++ b/src/endpoints/sdk/connections.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,6 +38,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -58,8 +62,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -85,8 +91,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -111,7 +119,9 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -136,6 +146,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -169,8 +181,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -214,6 +228,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -236,8 +252,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/sdk/endpoints.tools.ts
+++ b/src/endpoints/sdk/endpoints.tools.ts
@@ -14,6 +14,8 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -37,6 +39,8 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -60,8 +64,10 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -103,8 +109,10 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -172,7 +180,9 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -196,7 +206,12 @@ export const tools: MakeTool[] = [
         category: 'sdk-endpoints',
         scope: 'sdk-apps:write',
         scopeId: undefined,
-        annotations: { idempotentHint: true, destructiveHint: false },
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
         inputSchema: {
             type: 'object',
             properties: {
@@ -219,7 +234,12 @@ export const tools: MakeTool[] = [
         category: 'sdk-endpoints',
         scope: 'sdk-apps:write',
         scopeId: undefined,
-        annotations: { idempotentHint: true, destructiveHint: false },
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
         inputSchema: {
             type: 'object',
             properties: {
@@ -244,6 +264,8 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -280,8 +302,10 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/sdk/functions.tools.ts
+++ b/src/endpoints/sdk/functions.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,6 +38,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -60,8 +64,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -87,7 +93,9 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -114,6 +122,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -138,8 +148,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -177,6 +189,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -201,8 +215,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/sdk/modules.tools.ts
+++ b/src/endpoints/sdk/modules.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,6 +38,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -60,8 +64,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -115,8 +121,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -155,7 +163,9 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -182,6 +192,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -218,7 +230,12 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         identifier: undefined,
-        annotations: { idempotentHint: true, destructiveHint: false },
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
         inputSchema: {
             type: 'object',
             properties: {
@@ -242,7 +259,12 @@ export const tools: MakeTool[] = [
         scope: 'sdk-apps:write',
         scopeId: undefined,
         identifier: undefined,
-        annotations: { idempotentHint: true, destructiveHint: false },
+        annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+        },
         inputSchema: {
             type: 'object',
             properties: {
@@ -267,8 +289,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/sdk/rpcs.tools.ts
+++ b/src/endpoints/sdk/rpcs.tools.ts
@@ -13,6 +13,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -37,6 +39,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -61,8 +65,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -89,8 +95,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -129,7 +137,9 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -155,7 +165,9 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: true,
         },
         inputSchema: {
             type: 'object',
@@ -217,6 +229,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -254,8 +268,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/sdk/webhooks.tools.ts
+++ b/src/endpoints/sdk/webhooks.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -35,6 +37,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -57,8 +61,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -84,8 +90,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -110,7 +118,9 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -135,6 +145,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -168,8 +180,10 @@ export const tools: MakeTool[] = [
         scopeId: undefined,
         identifier: undefined,
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/teams.tools.ts
+++ b/src/endpoints/teams.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: 'organizationId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -36,6 +38,8 @@ export const tools: MakeTool[] = [
         resourceId: 'teamId',
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -58,8 +62,10 @@ export const tools: MakeTool[] = [
         scopeId: 'organizationId',
         identifier: 'organizationId',
         annotations: {
-            idempotentHint: true,
+            readOnlyHint: false,
             destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',
@@ -92,7 +98,9 @@ export const tools: MakeTool[] = [
         identifier: 'teamId',
         resourceId: 'teamId',
         annotations: {
+            readOnlyHint: false,
             destructiveHint: true,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/endpoints/users.tools.ts
+++ b/src/endpoints/users.tools.ts
@@ -12,6 +12,8 @@ export const tools: MakeTool[] = [
         identifier: undefined,
         annotations: {
             readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         inputSchema: {
             type: 'object',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -168,6 +168,13 @@ export type MakeTool = {
          * @default false
          */
         readOnlyHint?: boolean;
+
+        /**
+         * If true, the tool may interact with an "open world" of external
+         * entities. If false, the tool's domain of interaction is closed.
+         * @default true
+         */
+        openWorldHint?: boolean;
     };
 
     /** JSON Schema defining the input parameters */


### PR DESCRIPTION
## Finding
type: doc-gap · surface: mcp/sdk

All 161 tool definitions relied on MCP spec defaults for absent annotation hints. That's spec-legal, but the `openWorldHint` default is `true` ("this tool reaches an open-ended external world"), which misdescribes nearly every Make tool — they operate in the closed world of the Make platform. On top of that, marketplace reviews (ChatGPT plugin submission, per https://learn.chatgpt.com/codex/submit-plugins) require **all three hints explicit on every tool** and list inaccurate annotations as a rejection factor.

`openWorldHint` was set on **0/161 tools** — unsurprising, since the field didn't even exist on the `MakeTool` annotations type (`src/tools.ts`).

## Changes
- Every `annotations` block now states `readOnlyHint`, `destructiveHint`, and `openWorldHint` explicitly (canonical order; existing `idempotentHint` values preserved; no semantic values changed, only defaults made explicit).
- `openWorldHint: true` only for the three tools that genuinely reach external services: `scenarios_run` (executes user scenarios that call external apps), `connections_verify` (verifies against the third-party service), `sdk-rpcs_test` (executes an RPC against the third-party API).
- Added the missing `openWorldHint?: boolean` field to the `MakeTool` annotations type.

## Validation
- `npm run lint` clean (tsc + eslint)
- `npm test` — 34/34 suites, 259 tests green
- `npm run build` (tsup) OK
- Spot checks: `scenarios_list` → read-only/closed; `scenarios_delete` → destructive/closed; `scenarios_run` → destructive/open-world.

## Delivery note
Annotations reach mcp.make.com via the host's `sdk.module.ts` annotation passthrough — needs an SDK npm release + `make-mcp-server-host` dependency bump to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)