### PR TITLE
fix(hooks): apply manifest defaults on hook creation and document hook-type parameters

### DIFF
--- a/src/endpoints/hooks.tools.ts
+++ b/src/endpoints/hooks.tools.ts
@@ -75,13 +75,26 @@ export const tools: MakeTool[] = [
                 name: { type: 'string', description: 'The name of the webhook' },
                 typeName: {
                     type: 'string',
-                    description: 'The hook type related to the app for which it will be created',
+                    description:
+                        "The hook type to create. Use 'gateway-webhook' for a generic custom webhook (receives HTTP requests) or 'gateway-mailhook' for a generic mailhook (receives emails). For app-specific hooks, use the hook type name of that app (find it via the app's modules).",
                 },
-                data: { type: 'object', description: 'Additional data specific to the hook type' },
+                data: {
+                    type: 'object',
+                    description:
+                        "Additional parameters specific to the hook type. Required parameters that have defaults in the hook type's manifest are filled automatically when omitted (e.g. for 'gateway-webhook' the booleans 'method', 'headers' and 'stringify' default to false). Parameters without defaults must be provided here (e.g. app-specific hooks often require their own fields).",
+                },
             },
             required: ['teamId', 'name', 'typeName'],
         },
-        examples: [{ teamId: 5, name: 'My Webhook', typeName: 'gateway-webhook' }],
+        examples: [
+            { teamId: 5, name: 'My Webhook', typeName: 'gateway-webhook' },
+            {
+                teamId: 5,
+                name: 'My Webhook with headers',
+                typeName: 'gateway-webhook',
+                data: { method: true, headers: true, stringify: false },
+            },
+        ],
         execute: async (
             make: Make,
             args: {

--- a/src/endpoints/hooks.ts
+++ b/src/endpoints/hooks.ts
@@ -177,6 +177,9 @@ export class Hooks {
 
     /**
      * Create a new hook.
+     * Required hook-type parameters that have a default value in the hook type's
+     * manifest (e.g. `method`, `headers`, `stringify` for `gateway-webhook`) are
+     * filled by the API when omitted from `data`; values provided in `data` take precedence.
      * @param body The hook configuration to create
      * @returns Promise with the created hook
      */
@@ -184,6 +187,9 @@ export class Hooks {
         return (
             await this.#fetch<CreateHookResponse>('/hooks', {
                 method: 'POST',
+                query: {
+                    useDefaults: 'requiredOnly',
+                },
                 body: Object.assign({}, body.data, {
                     name: body.name,
                     teamId: body.teamId,

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -36,12 +36,31 @@ describe('Endpoints: Hooks', () => {
                 },
             };
 
-            mockFetch('POST https://make.local/api/v2/hooks', hookCreateMock, req => {
+            mockFetch('POST https://make.local/api/v2/hooks?useDefaults=requiredOnly', hookCreateMock, req => {
                 expect(req.body).toStrictEqual({
                     name: body.name,
                     teamId: body.teamId,
                     typeName: body.typeName,
                     formId: body.data.formId,
+                });
+            });
+
+            const result = await make.hooks.create(body);
+            expect(result).toStrictEqual(hookCreateMock.hook);
+        });
+
+        it('Should create a webhook without type-specific data by applying manifest defaults', async () => {
+            const body = {
+                name: 'My Webhook',
+                teamId: 4,
+                typeName: 'gateway-webhook',
+            };
+
+            mockFetch('POST https://make.local/api/v2/hooks?useDefaults=requiredOnly', hookCreateMock, req => {
+                expect(req.body).toStrictEqual({
+                    name: body.name,
+                    teamId: body.teamId,
+                    typeName: body.typeName,
                 });
             });
 


### PR DESCRIPTION
Jira: [WM-4172](https://make.atlassian.net/browse/WM-4172)

# hooks_create fails 52% of production MCP calls on missing manifest-default params

## Finding
type: code-bug (SDK request construction) + doc-gap (tool metadata)
surface(s): sdk, mcp (and any MakeTools consumer)

`hooks_create` is the highest-error tool on the MCP surface: 3,145 of 5,992 calls failed over the last 7 days (Datadog APM, `service:mcp-server-host resource_name:sdk-module.hooks$hooks_create`). 88% of failures are a single API validation error — `Missing value of required parameter 'headers' / 'method' / 'stringify'` — three gateway-webhook manifest parameters that agents cannot know about: they are not in the tool schema, and the tool's own example (`{teamId, name, typeName: 'gateway-webhook'}`) reproduces the error verbatim. The second-largest class (7.7%) is `Failed to load manifest.json file for hook '<x>'` — agents guessing invalid `typeName` values because the description names none.

## Evidence
- Datadog (7d, prod): error fingerprint `v12.4A381E3B274D1629433A6F70D06611A0` = 2,778 of 3,145 errors; `v12.B154AD331019A32598A4DA9E8B0D94D8` (invalid typeName) = 243. Error Tracking issue `b5df79e4-1dca-11f0-9cd3-da7ad0900002`, first seen 2025-04-20.
- Re-runnable: `aggregate_spans` on `service:mcp-server-host resource_name:sdk-module.hooks\$hooks_create status:error` grouped by `@error.fingerprint`.

## Mapping
- `mono/libs/native-apps/gateway/manifest.json` — gateway-webhook params `headers`, `method`, `stringify`: `required: true` **with `default: false`**.
- `imt-web-api/lib/controllers/hooks.js:333` — `validate(req, 'body', conf, false, false, query.useDefaults ?? false)`: manifest defaults are applied **only when the caller sends `useDefaults`** (`always` | `requiredOnly`, `lib/controllers/validations/query.js:40-53`). The Make UI sends it; the SDK never did (`src/endpoints/hooks.ts`).

## Fix
- `hooks.create` now sends `useDefaults=requiredOnly`: the API fills omitted required params that have manifest defaults; values provided in `data` still take precedence (they're spread into the body and validated as before). Required params **without** defaults (e.g. gateway-formhook's `udt`) still validate-fail, as they should.
- `hooks.tools.ts`: `typeName` description now names the valid generic types (`gateway-webhook`, `gateway-mailhook`) and how app-specific types work; `data` description explains the defaults behavior and when fields are mandatory; added a second example with explicit webhook options.

Alternative rejected: adding `method`/`headers`/`stringify` to the tool schema — they are type-specific (wrong for mailhooks/app hooks), and `useDefaults` is the mechanism the product UI itself relies on.

Delivery chain: this PR → `@makehq/sdk` npm release → `make-mcp-server-host` dependency bump + deploy.

## Validation
- Regression tests: both create tests in `test/hooks.spec.ts` fail pre-fix (`Unmocked HTTP request: POST .../hooks` — no `useDefaults` query sent) and pass post-fix; new test covers the bare `{teamId, name, typeName: 'gateway-webhook'}` call that dominates production failures.
- Full suite: 34 suites / 261 tests green + `npm run lint` clean on the branch's final state.
- Post-deploy check: the fingerprint `4A381E3B…` share of `hooks_create` errors should collapse (same Datadog query as above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WM-4172]: https://make.atlassian.net/browse/WM-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ