### PR TITLE
chore: bump version to 1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.3",
+            "version": "1.6.4",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",


### PR DESCRIPTION
Bump version to 1.6.4 for release.

Changes since v1.6.3:
- feat: add "includePrivateSpaces" param to `teams.list()` (#70)
- fix(hooks): apply manifest defaults on hook creation and document hook-type parameters (#71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)