### PR TITLE
fix(tools): type blueprint/scheduling schemas and document state traps in tool contracts (WM-4172)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",

--- a/src/endpoints/credential-requests.tools.ts
+++ b/src/endpoints/credential-requests.tools.ts
@@ -96,7 +96,11 @@ export const tools: MakeTool[] = [
         inputSchema: {
             type: 'object',
             properties: {
-                requestId: { type: 'string', description: 'The credential request ID to delete' },
+                requestId: {
+                    type: 'string',
+                    description:
+                        'The credential request ID to delete — the string ID returned by credential-requests_create or credential-requests_list. NOT a numeric connectionId; to delete a connection use connections_delete.',
+                },
             },
             required: ['requestId'],
         },
@@ -427,7 +431,7 @@ export const tools: MakeTool[] = [
         description:
             'Add new OAuth scopes to an existing connection. Use this when a connection exists but lacks the permissions (scopes) needed for a specific operation. ' +
             'Creates a credential request that the end-user must authorize via the returned publicUri to grant the additional scopes. ' +
-            'Fails if all requested scopes are already present on the connection.',
+            'Fails if all requested scopes are already present on the connection — that error means the connection already satisfies the requirement: treat it as success and use the connection as-is; do not retry.',
         category: 'credential-requests',
         scope: 'credential-requests:write',
         scopeId: 'connectionId',
@@ -450,7 +454,7 @@ export const tools: MakeTool[] = [
                 scopes: {
                     type: 'array',
                     description:
-                        'One or more new OAuth scope strings to add to the connection. At least one scope must be new (not already granted).',
+                        'One or more new OAuth scope strings to add to the connection. At least one scope must be new (not already granted). Get the exact scope strings a module needs from credential-requests_list-app-modules-with-creds — do not guess them.',
                     minItems: 1,
                     items: {
                         type: 'string',

--- a/src/endpoints/executions.tools.ts
+++ b/src/endpoints/executions.tools.ts
@@ -147,9 +147,8 @@ export const tools: MakeTool[] = [
                 incompleteExecutionId: { type: 'string', description: 'The incomplete execution ID' },
                 executionId: {
                     type: 'string',
-                    pattern: '^[0-9a-f]{32}$',
                     description:
-                        "The execution ID to retrieve — a 32-character lowercase hex string as returned by scenarios_run or executions_list (e.g. 'a07e16f2ad134bf49cf83a00aa95c0a5')",
+                        "The execution ID from the incomplete execution record (see executions_list-for-incomp-exec) — may be UUID-formatted with dashes (e.g. '55602700-e840-45bf-b18c-0aef214dd967'), unlike scenario execution IDs",
                 },
             },
             required: ['incompleteExecutionId', 'executionId'],

--- a/src/endpoints/executions.tools.ts
+++ b/src/endpoints/executions.tools.ts
@@ -34,7 +34,8 @@ export const tools: MakeTool[] = [
     {
         name: 'executions_get-detail',
         title: 'Get execution detail',
-        description: 'Get detailed result of a specific execution.',
+        description:
+            'Get the full per-module detail of an execution: the inputs and outputs of each module, the failing module and its error. ALWAYS call this after a failed or suspicious run BEFORE retrying or editing the scenario. For lightweight status/duration metadata only, use executions_get instead.',
         category: 'executions',
         scope: 'scenarios:read',
         scopeId: 'scenarioId',
@@ -49,7 +50,12 @@ export const tools: MakeTool[] = [
             type: 'object',
             properties: {
                 scenarioId: { type: 'number', description: 'The scenario ID the execution belongs to' },
-                executionId: { type: 'string', description: 'The execution ID to retrieve' },
+                executionId: {
+                    type: 'string',
+                    pattern: '^[0-9a-f]{32}$',
+                    description:
+                        "The execution ID to retrieve — a 32-character lowercase hex string as returned by scenarios_run or executions_list (e.g. 'a07e16f2ad134bf49cf83a00aa95c0a5')",
+                },
             },
             required: ['scenarioId', 'executionId'],
         },
@@ -61,7 +67,8 @@ export const tools: MakeTool[] = [
     {
         name: 'executions_get',
         title: 'Get execution',
-        description: 'Get details of a specific execution.',
+        description:
+            'Get execution metadata only: status, duration, operations consumed and error class — NOT per-module inputs/outputs. To see what each module did or why a run failed, use executions_get-detail instead.',
         category: 'executions',
         scope: 'scenarios:read',
         scopeId: 'scenarioId',
@@ -76,7 +83,12 @@ export const tools: MakeTool[] = [
             type: 'object',
             properties: {
                 scenarioId: { type: 'number', description: 'The scenario ID the execution belongs to' },
-                executionId: { type: 'string', description: 'The execution ID to retrieve' },
+                executionId: {
+                    type: 'string',
+                    pattern: '^[0-9a-f]{32}$',
+                    description:
+                        "The execution ID to retrieve — a 32-character lowercase hex string as returned by scenarios_run or executions_list (e.g. 'a07e16f2ad134bf49cf83a00aa95c0a5')",
+                },
             },
             required: ['scenarioId', 'executionId'],
         },
@@ -133,7 +145,12 @@ export const tools: MakeTool[] = [
             type: 'object',
             properties: {
                 incompleteExecutionId: { type: 'string', description: 'The incomplete execution ID' },
-                executionId: { type: 'string', description: 'The execution ID to retrieve' },
+                executionId: {
+                    type: 'string',
+                    pattern: '^[0-9a-f]{32}$',
+                    description:
+                        "The execution ID to retrieve — a 32-character lowercase hex string as returned by scenarios_run or executions_list (e.g. 'a07e16f2ad134bf49cf83a00aa95c0a5')",
+                },
             },
             required: ['incompleteExecutionId', 'executionId'],
         },

--- a/src/endpoints/folders.tools.ts
+++ b/src/endpoints/folders.tools.ts
@@ -5,7 +5,8 @@ export const tools: MakeTool[] = [
     {
         name: 'folders_list',
         title: 'List folders',
-        description: 'List folders for a team.',
+        description:
+            "List scenario folders for a team. If this fails with 'Access denied', the teamId is not accessible to your token — call users_me to learn your teamId instead of retrying with guessed IDs.",
         category: 'folders',
         scope: 'scenarios:read',
         scopeId: 'teamId',

--- a/src/endpoints/folders.tools.ts
+++ b/src/endpoints/folders.tools.ts
@@ -5,8 +5,7 @@ export const tools: MakeTool[] = [
     {
         name: 'folders_list',
         title: 'List folders',
-        description:
-            "List scenario folders for a team. If this fails with 'Access denied', the teamId is not accessible to your token — call users_me to learn your teamId instead of retrying with guessed IDs.",
+        description: 'List scenario folders for a team. If you do not know the teamId, call users_me to learn it.',
         category: 'folders',
         scope: 'scenarios:read',
         scopeId: 'teamId',

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -2,13 +2,13 @@ import type { Blueprint, DataStructureField } from '../index.js';
 import type { Make } from '../make.js';
 import type { JSONValue } from '../types.js';
 import type { Scheduling } from './scenarios.js';
-import type { MakeTool } from '../tools.js';
+import type { JSONSchema, MakeTool } from '../tools.js';
 
 /**
  * JSON Schema for the `scheduling` parameter of `scenarios_create` / `scenarios_update`.
  * Mirrors the {@link Scheduling} type; the API also accepts a JSON-encoded string of the same shape.
  */
-const schedulingInputSchema = {
+const schedulingInputSchema: JSONSchema = {
     type: 'object',
     description:
         "Scheduling configuration. Only the listed properties exist — there is no 'cron', 'hour' or similar property.",
@@ -60,7 +60,7 @@ const schedulingInputSchema = {
  * JSON Schema for the `blueprint` parameter of `scenarios_create` / `scenarios_update`.
  * Mirrors the {@link Blueprint} type; the API also accepts a JSON-encoded string of the same shape.
  */
-const blueprintInputSchema = {
+const blueprintInputSchema: JSONSchema = {
     type: 'object',
     description:
         "Blueprint containing the scenario configuration. Every `module` value must be an existing module identifier verified via app-modules_list — never invent module names.",

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -4,6 +4,111 @@ import type { JSONValue } from '../types.js';
 import type { Scheduling } from './scenarios.js';
 import type { MakeTool } from '../tools.js';
 
+/**
+ * JSON Schema for the `scheduling` parameter of `scenarios_create` / `scenarios_update`.
+ * Mirrors the {@link Scheduling} type; the API also accepts a JSON-encoded string of the same shape.
+ */
+const schedulingInputSchema = {
+    type: 'object',
+    description:
+        "Scheduling configuration. Only the listed properties exist — there is no 'cron', 'hour' or similar property.",
+    properties: {
+        type: {
+            type: 'string',
+            enum: ['immediately', 'indefinitely', 'once', 'daily', 'weekly', 'monthly', 'yearly', 'on-demand'],
+            description:
+                "Type of scheduling. 'indefinitely' runs on an interval; 'on-demand' only runs when triggered manually or via scenarios_run.",
+        },
+        interval: {
+            type: 'number',
+            minimum: 60,
+            description: "Interval in seconds when type is 'indefinitely' (minimum 60)",
+        },
+        date: { type: 'string', description: "Date and time to run the scenario when type is 'once' (ISO 8601)" },
+        days: {
+            type: 'array',
+            items: { type: 'number' },
+            description:
+                "Days of the week to run the scenario when type is 'weekly' (0-6, where 0 is Sunday); days of the month when type is 'monthly' or 'yearly' (1-31)",
+        },
+        months: {
+            type: 'array',
+            items: { type: 'number' },
+            description: "Months of the year to run the scenario when type is 'yearly' (1-12)",
+        },
+        time: {
+            type: 'string',
+            description:
+                "Time of day to run the scenario when type is 'daily', 'weekly', 'monthly', or 'yearly' (e.g. '09:00')",
+        },
+        between: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Date and time range the scenario may run in, for all types (ISO 8601)',
+        },
+        restrict: {
+            type: 'array',
+            items: { type: 'object' },
+            description: 'Restrictions for scheduling (days/months/time windows)',
+        },
+    },
+    required: ['type'],
+    additionalProperties: false,
+};
+
+/**
+ * JSON Schema for the `blueprint` parameter of `scenarios_create` / `scenarios_update`.
+ * Mirrors the {@link Blueprint} type; the API also accepts a JSON-encoded string of the same shape.
+ */
+const blueprintInputSchema = {
+    type: 'object',
+    description:
+        "Blueprint containing the scenario configuration. Every `module` value must be an existing module identifier verified via app-modules_list — never invent module names.",
+    properties: {
+        name: { type: 'string', description: 'Name of the scenario' },
+        flow: {
+            type: 'array',
+            description:
+                "Modules of the scenario in execution order. A module's filter lives in its `filter` property; there is no `epoch` property anywhere in a blueprint.",
+            items: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'number',
+                        description: 'Unique numeric identifier of the module within the blueprint',
+                    },
+                    module: {
+                        type: 'string',
+                        description:
+                            "Module identifier in `app:ModuleName` format (e.g. 'http:ActionSendData'). Must exist — verify via app-modules_list / app-module_get; never guess",
+                    },
+                    version: { type: 'number', description: 'Version of the module' },
+                    parameters: { type: 'object', description: 'Static module parameters' },
+                    mapper: { type: 'object', description: 'Mappable module parameters' },
+                    metadata: { type: 'object', description: 'Module metadata' },
+                    routes: {
+                        type: 'array',
+                        items: { type: 'object' },
+                        description: 'Routes to other nodes, each `{"flow": [...]}` — only for router modules',
+                    },
+                    onerror: { type: 'array', items: { type: 'object' }, description: 'Error handling modules' },
+                    filter: {
+                        type: 'object',
+                        description:
+                            'Filter applied before this module runs: `{"name": "...", "conditions": [[{"a": "...", "o": "text:equal", "b": "..."}]]}`',
+                    },
+                },
+                required: ['id', 'module', 'version'],
+            },
+        },
+        metadata: {
+            type: 'object',
+            description: 'Metadata for the blueprint — required by the API; use `{"version": 1}` if unsure',
+        },
+    },
+    required: ['name', 'flow', 'metadata'],
+};
+
 export const tools: MakeTool[] = [
     {
         name: 'scenarios_list',
@@ -65,7 +170,8 @@ export const tools: MakeTool[] = [
     {
         name: 'scenarios_create',
         title: 'Create scenario',
-        description: 'Create a new scenario.',
+        description:
+            'Create a new scenario from a blueprint. Verify every module name in the blueprint via app-modules_list before creating — never invent module identifiers. The created scenario starts INACTIVE: call scenarios_activate before scenarios_run can execute it.',
         category: 'scenarios',
         scope: 'scenarios:write',
         scopeId: 'teamId',
@@ -81,8 +187,8 @@ export const tools: MakeTool[] = [
             properties: {
                 teamId: { type: 'number', description: 'ID of the team where the scenario will be created' },
                 folderId: { type: 'number', description: 'ID of the folder where the scenario will be placed' },
-                scheduling: { description: 'Scheduling configuration for the scenario' },
-                blueprint: { description: 'Blueprint containing the scenario configuration' },
+                scheduling: schedulingInputSchema,
+                blueprint: blueprintInputSchema,
                 basedon: { type: 'string', description: 'ID of an existing template to base this one on' },
                 confirmed: {
                     type: 'boolean',
@@ -94,9 +200,29 @@ export const tools: MakeTool[] = [
         examples: [
             {
                 teamId: 5,
-                scheduling: '{"type":"indefinitely","interval":60}',
-                blueprint:
-                    '{"name":"Gmail Attachments to Google Drive","flow":[{"id":1,"module":"google-email:watchEmails","version":1,"parameters":{"connection":5,"folder":"INBOX","filter":"has:attachment"},"mapper":{},"metadata":{"expect":[]}},{"id":2,"module":"google-drive:uploadFile","version":1,"parameters":{"connection":6},"mapper":{"folderId":"your-folder-id-here","file":"{{1.attachments[]}}"},"metadata":{"expect":[]}}],"metadata":{"version":1}}',
+                scheduling: { type: 'indefinitely', interval: 60 },
+                blueprint: {
+                    name: 'Gmail Attachments to Google Drive',
+                    flow: [
+                        {
+                            id: 1,
+                            module: 'google-email:watchEmails',
+                            version: 1,
+                            parameters: { connection: 5, folder: 'INBOX', filter: 'has:attachment' },
+                            mapper: {},
+                            metadata: { expect: [] },
+                        },
+                        {
+                            id: 2,
+                            module: 'google-drive:uploadFile',
+                            version: 1,
+                            parameters: { connection: 6 },
+                            mapper: { folderId: 'your-folder-id-here', file: '{{1.attachments[]}}' },
+                            metadata: { expect: [] },
+                        },
+                    ],
+                    metadata: { version: 1 },
+                },
             },
         ],
         execute: async (
@@ -117,7 +243,8 @@ export const tools: MakeTool[] = [
     {
         name: 'scenarios_update',
         title: 'Update scenario',
-        description: 'Update a scenario.',
+        description:
+            'Update a scenario. The `blueprint` parameter wholesale-REPLACES the existing blueprint (no merging): always fetch the current blueprint with scenarios_get first, edit that JSON, and send the complete result. Tool scenarios (created via tools_create) cannot be blueprint-edited with this tool — use tools_update.',
         category: 'scenarios',
         scope: 'scenarios:write',
         scopeId: 'scenarioId',
@@ -134,10 +261,14 @@ export const tools: MakeTool[] = [
             properties: {
                 scenarioId: { type: 'number', description: 'The scenario ID to update' },
                 name: { type: 'string', description: 'New name for the scenario' },
-                description: { type: 'string', description: 'New description for the scenario' },
+                description: {
+                    type: 'string',
+                    maxLength: 240,
+                    description: 'New description for the scenario (maximum 240 characters)',
+                },
                 folderId: { type: 'number', description: 'New folder ID for the scenario' },
-                scheduling: { description: 'Updated scheduling configuration' },
-                blueprint: { description: 'Updated blueprint configuration' },
+                scheduling: schedulingInputSchema,
+                blueprint: blueprintInputSchema,
                 confirmed: {
                     type: 'boolean',
                     description: 'Confirmation in case the scenario uses apps that are not yet installed',
@@ -149,7 +280,7 @@ export const tools: MakeTool[] = [
             {
                 scenarioId: 925,
                 name: 'Updated Scenario',
-                scheduling: '{"type":"indefinitely","interval":900}',
+                scheduling: { type: 'indefinitely', interval: 900 },
             },
         ],
         execute: async (
@@ -198,7 +329,8 @@ export const tools: MakeTool[] = [
     {
         name: 'scenarios_activate',
         title: 'Activate scenario',
-        description: 'Activate a scenario.',
+        description:
+            "Activate a scenario. Required before scenarios_run can execute it. If this fails with 'Scenario is already running', the scenario is already active — treat that as success and do not retry.",
         category: 'scenarios',
         scope: 'scenarios:write',
         scopeId: 'scenarioId',
@@ -227,7 +359,8 @@ export const tools: MakeTool[] = [
     {
         name: 'scenarios_deactivate',
         title: 'Deactivate scenario',
-        description: 'Deactivate a scenario.',
+        description:
+            "Deactivate a scenario. If this fails with 'Scenario is not running', the scenario is already inactive — treat that as success and do not retry.",
         category: 'scenarios',
         scope: 'scenarios:write',
         scopeId: 'scenarioId',
@@ -256,7 +389,8 @@ export const tools: MakeTool[] = [
     {
         name: 'scenarios_run',
         title: 'Run scenario',
-        description: 'Execute a scenario with optional input data.',
+        description:
+            "Execute a scenario with optional input data. The scenario must be ACTIVE — a run of an inactive scenario fails with 'Scenario is not activated', so call scenarios_activate first (newly created scenarios start inactive). Returns an executionId: after a failed or suspicious run, inspect it with executions_get-detail BEFORE retrying or editing the scenario. A scenario cannot run twice concurrently — on 'Scenario is already being executed', wait for the running execution instead of retrying.",
         category: 'scenarios',
         scope: 'scenarios:run',
         scopeId: 'scenarioId',
@@ -271,8 +405,16 @@ export const tools: MakeTool[] = [
             type: 'object',
             properties: {
                 scenarioId: { type: 'number', description: 'The scenario ID to run' },
-                data: { type: 'object', description: 'Optional input data for the scenario' },
-                responsive: { type: 'boolean', description: 'Whether to run responsively' },
+                data: {
+                    type: 'object',
+                    description:
+                        "Optional input data for the scenario. Keys must match the scenario's input interface — check it with scenarios_interface",
+                },
+                responsive: {
+                    type: 'boolean',
+                    description:
+                        'When true, waits for the execution to finish and returns its outputs; when false, the run is only queued and the executionId is returned immediately',
+                },
                 callbackUrl: { type: 'string', description: 'URL to call once the scenario execution finishes' },
             },
             required: ['scenarioId'],

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -6,12 +6,16 @@ import type { JSONSchema, MakeTool } from '../tools.js';
 
 /**
  * JSON Schema for the `scheduling` parameter of `scenarios_create` / `scenarios_update`.
- * Mirrors the {@link Scheduling} type; the API also accepts a JSON-encoded string of the same shape.
+ * Mirrors the {@link Scheduling} type. The API itself also accepts a JSON-encoded string of the
+ * same shape, but validating consumers (the MCP host) enforce the object form declared here.
+ * Type-specific guidance is duplicated in the parent description because schema conversion on the
+ * MCP host may drop annotations from enum properties.
  */
 const schedulingInputSchema: JSONSchema = {
     type: 'object',
     description:
-        "Scheduling configuration. Only the listed properties exist — there is no 'cron', 'hour' or similar property.",
+        "Scheduling configuration. Only the listed properties exist — there is no 'cron', 'hour' or similar property. " +
+        "`type` must be one of: 'immediately', 'indefinitely' (runs on `interval` seconds), 'once', 'daily', 'weekly', 'monthly', 'yearly', or 'on-demand' (only runs when triggered manually or via scenarios_run).",
     properties: {
         type: {
             type: 'string',
@@ -58,7 +62,13 @@ const schedulingInputSchema: JSONSchema = {
 
 /**
  * JSON Schema for the `blueprint` parameter of `scenarios_create` / `scenarios_update`.
- * Mirrors the {@link Blueprint} type; the API also accepts a JSON-encoded string of the same shape.
+ * Mirrors the {@link Blueprint} type. The API itself also accepts a JSON-encoded string of the
+ * same shape, but validating consumers (the MCP host) enforce the object form declared here.
+ *
+ * `additionalProperties: true` (here and on `flow.items`) is load-bearing: blueprints carry more
+ * properties than this schema declares (e.g. a webhook node's `listener`), and the MCP host's
+ * validation pipeline strips undeclared properties from a `scenarios_get` → edit →
+ * `scenarios_update` round-trip unless the schema explicitly allows them.
  */
 const blueprintInputSchema: JSONSchema = {
     type: 'object',
@@ -99,6 +109,7 @@ const blueprintInputSchema: JSONSchema = {
                     },
                 },
                 required: ['id', 'module', 'version'],
+                additionalProperties: true,
             },
         },
         metadata: {
@@ -107,6 +118,7 @@ const blueprintInputSchema: JSONSchema = {
         },
     },
     required: ['name', 'flow', 'metadata'],
+    additionalProperties: true,
 };
 
 export const tools: MakeTool[] = [

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -8,14 +8,11 @@ import type { JSONSchema, MakeTool } from '../tools.js';
  * JSON Schema for the `scheduling` parameter of `scenarios_create` / `scenarios_update`.
  * Mirrors the {@link Scheduling} type. The API itself also accepts a JSON-encoded string of the
  * same shape, but validating consumers (the MCP host) enforce the object form declared here.
- * Type-specific guidance is duplicated in the parent description because schema conversion on the
- * MCP host may drop annotations from enum properties.
  */
 const schedulingInputSchema: JSONSchema = {
     type: 'object',
     description:
-        "Scheduling configuration. Only the listed properties exist — there is no 'cron', 'hour' or similar property. " +
-        "`type` must be one of: 'immediately', 'indefinitely' (runs on `interval` seconds), 'once', 'daily', 'weekly', 'monthly', 'yearly', or 'on-demand' (only runs when triggered manually or via scenarios_run).",
+        "Scheduling configuration. Only the listed properties exist — there is no 'cron', 'hour' or similar property.",
     properties: {
         type: {
             type: 'string',

--- a/src/endpoints/teams.tools.ts
+++ b/src/endpoints/teams.tools.ts
@@ -6,7 +6,7 @@ export const tools: MakeTool[] = [
         name: 'teams_list',
         title: 'List teams',
         description:
-            "List the teams of an organization. Requires an organizationId — get it from organizations_list or users_me. If this fails with 'Access denied', your token is team-scoped and cannot list an organization's teams: call users_me to learn your teamId and use teams_get instead; do not retry with guessed organization IDs.",
+            "List the teams of an organization. Requires an organizationId — get it from organizations_list or users_me. 'Access denied' means your token is team-scoped and cannot list teams: call users_me to learn your teamId and use teams_get instead.",
         category: 'teams',
         scope: 'teams:read',
         scopeId: 'organizationId',

--- a/src/endpoints/teams.tools.ts
+++ b/src/endpoints/teams.tools.ts
@@ -5,7 +5,8 @@ export const tools: MakeTool[] = [
     {
         name: 'teams_list',
         title: 'List teams',
-        description: 'List teams for the current user.',
+        description:
+            "List the teams of an organization. Requires an organizationId — get it from organizations_list or users_me. If this fails with 'Access denied', your token is team-scoped and cannot list an organization's teams: call users_me to learn your teamId and use teams_get instead; do not retry with guessed organization IDs.",
         category: 'teams',
         scope: 'teams:read',
         scopeId: 'organizationId',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -76,6 +76,8 @@ export type JSONSchema = {
     maxItems?: number;
     /** Pattern for string validation */
     pattern?: string;
+    /** Whether properties not listed in `properties` are allowed on object types */
+    additionalProperties?: boolean;
 };
 
 /**


### PR DESCRIPTION
# Level 1 tool-contract fixes: typed blueprint/scheduling, state-trap docs, tool differentiation (2026-07-17, agent-interfaces-self-improve iteration 5, case SX-006)

## Finding
type: doc-gap
surface(s): mcp | sdk (MakeTools metadata consumed by mcp.make.com and the CLI)

The six highest-failing MCP tools all carry "legacy dialect" contracts: `scenarios_create`/`scenarios_update` accept `blueprint` and `scheduling` with **no `type` key at all** and one-line descriptions, `scenarios_run` says nothing about the activation requirement, and `executions_get` vs `executions_get-detail` are indistinguishable. Production telemetry (Datadog APM spans, `service:mcp-server-host operation_name:mcp.tool_call status:error`, 14d windows ending 2026-07-17) shows agents paying for every one of these gaps.

## Evidence
- "Scenario is not activated" on `scenarios_run`: **10,315** (~28% of all 36.7K run calls) — the natural create→run loop fails because nothing in the contract says runs require activation.
- Idempotency traps: "Scenario is already running" 2,711 (`scenarios_activate`), "Scenario is not running" 2,863 (`scenarios_deactivate`), "Scenario is already being executed" 2,292 (`scenarios_run` retry loops).
- Blueprint/scheduling guessing on create/update: invalid `scheduling.type` 967 (agents invent `cron`, `hour`); blueprint missing required `metadata` 540; "Value exceeded maximum length of 240 chars in parameter 'description'" 1,043; a systematic long tail of invented module slugs (`builtin:TextAggregator`, `util:SetVariables2`, `google-sheets:searchRows@2`, …).
- `executions_get`/`executions_get-detail`: "Value doesn't match pattern in parameter 'executionId'" 673 (format undocumented).
- `teams_list`: 676 errors of 1,402 calls (~48%) — org-scoping guidance absent.
- `credential-requests_extend-connection` 96.8% error rate (30d): errors when scopes are already present (error-as-answer); `credential-requests_delete` requestId provenance undocumented.

Full research: `make-ai-test-harness/mcp-authoring-failure-modes.md` (FM-A, FM-B, FM-C, FM-D).

## Mapping
All in `src/endpoints/*.tools.ts` (the MakeTools metadata that powers `tools/list` on mcp.make.com via sdk.module auto-registration):
- `scenarios.tools.ts` — untyped `blueprint`/`scheduling` on create (was line 84-85) and update (was 139-140); one-line descriptions on create/update/run/activate/deactivate.
- `executions.tools.ts` — identical descriptions for get vs get-detail (was lines 37/64); untyped executionId.
- `teams.tools.ts:8`, `folders.tools.ts:8` — no Access-denied recovery.
- `credential-requests.tools.ts` (extend-connection was line 430, delete was line 99).

## Fix
Description/schema-only changes; no `execute` behavior touched:
- `blueprint` and `scheduling` get full JSON Schemas mirroring the SDK's own `Blueprint`/`Scheduling` TS types (shared consts): `scheduling.type` enum, `interval` minimum, `additionalProperties: false` on scheduling; blueprint requires `name`/`flow`/`metadata`, flow items require `id`/`module`/`version`, module-id format guidance ("verify via app-modules_list — never invent"). The blueprint object and its flow items carry `additionalProperties: true` — load-bearing, see **Host dependency** below.
- **Intentional breaking change on the MCP surface:** the old examples taught agents to pass `blueprint`/`scheduling` as JSON strings; with `type: 'object'` declared, the host's validation now rejects the string form before it reaches the API (the API's own `normalizePayload` still accepts strings, but MCP tool calls never get that far). The rejection error ("Expected object") is clear enough to self-correct in one turn, and objects are the contract we want agents on. Examples are converted to objects accordingly.
- `scenarios_update`: wholesale-replace warning (fetch with `scenarios_get` first), tool-scenario exclusion, `maxLength: 240` on `description`.
- `scenarios_run`: activation requirement, executionId → `executions_get-detail` before retrying, concurrent-run trap, `data`-keys-must-match-interface, `responsive` semantics.
- `scenarios_activate`/`deactivate`: already-in-state errors documented as success — do not retry.
- `executions_get` vs `executions_get-detail`: differentiated (metadata-only vs per-module I/O + "ALWAYS call after a failed run"); executionId documented with `pattern: ^[0-9a-f]{32}$`.
- `teams_list`/`folders_list`: Access-denied recovery via users_me. (Making `organizationId` optional requires backend support in imt-web-api — out of scope here, tracked as a Level-3 item.)
- `credential-requests_extend-connection`: "all scopes already present" error documented as satisfied-requirement; exact scope strings via `credential-requests_list-app-modules-with-creds`. `credential-requests_delete`: requestId provenance (string ID from create/list, NOT a connectionId).
- `scheduling.type`'s behavioral guidance lives on the enum property's own `description`. The host's schema conversion used to drop annotations from enum properties; make-mcp-server-host#338 fixes that, and since #338 is a hard prerequisite of this release anyway (see below), no duplication into the parent description is needed. The enum *values* always survived conversion (as `anyOf` consts), so they aren't repeated in prose either.

## Host dependency & release ordering (from review)
The host validates every tool call against these schemas via `FromSchema` → `Value.Clean` → `Value.Check`. `Value.Clean` strips undeclared object properties, and real blueprints carry more properties than any schema will ever declare (e.g. a webhook node's `listener`) — without `additionalProperties: true` the recommended `scenarios_get` → edit → `scenarios_update` loop would **silently corrupt blueprints**. TypeBox only honors the boolean form after [make-mcp-server-host#338](https://github.com/integromat/make-mcp-server-host/pull/338) (maps `additionalProperties: true` → `Type.Unknown()`; also preserves enum-property descriptions).

**Ordering:** #338 must be deployed on the host **before or together with** the `@makehq/sdk` bump that picks up this PR. #338 is a no-op until then, so it can merge anytime; plan is to land #338 now and do the SDK bump in the same release once the npm package is published.

Delivery chain: this PR carries the version bump to **1.6.5** — npm release on merge → make-mcp-server-host bumps `@makehq/sdk` (with #338 already in) → host deploy. Quick prod mitigation meanwhile: GrowthBook `mcp-tool-description_{toolName}` overrides.
Companion PR (host-only tools, same finding class): make-mcp-server-host #337. Each PR is independently useful; this one only reaches production through the SDK release + host bump.

## Validation
- `npm run lint` (tsc + eslint) green; `npm test` (full jest unit suite, 261 tests) green on the final state of the branch.
- End-to-end against the host's real validation pipeline (branch `dist/tools.cjs` + #338's `FromSchema` + `TypeBoxValidationUtil`): webhook-blueprint round-trip preserves `listener` and undeclared top-level keys; invalid `scheduling.type`, missing blueprint `metadata`, over-long `description`, and malformed `executionId` are all still rejected with actionable errors; `scheduling.type` description survives onto the converted schema.
- Post-deploy check: the error signatures above should decay in `service:mcp-server-host operation_name:mcp.tool_call status:error` spans (re-runnable queries in mcp-authoring-failure-modes.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Jira: [WM-4172](https://make-com.atlassian.net/browse/WM-4172)


[WM-4172]: https://make.atlassian.net/browse/WM-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
