### PR TITLE
chore: bump version to 1.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.5",
+            "version": "1.6.6",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",


### PR DESCRIPTION
[AI code generation]

## Summary
- Bump version to 1.6.6 for release.

Changes since v1.6.5:
- feat(private-spaces): add private spaces endpoints, tools and organization field (ORB-1919) (#74)

## Test plan
- [x] `npm run lint` passes (`tsc` + `eslint`)
- [x] `npx prettier --check` passes on changed files (package.json, package-lock.json)