### PR TITLE
feat(executions): add maxBytes option to getDetail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.9",
+    "version": "1.6.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.9",
+            "version": "1.6.10",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.9",
+    "version": "1.6.10",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",

--- a/src/endpoints/executions.ts
+++ b/src/endpoints/executions.ts
@@ -112,6 +112,14 @@ type GetIncompleteExecutionExecutionResponse = {
 };
 
 /**
+ * Options for getting detailed execution result.
+ */
+export type GetExecutionDetailOptions = {
+    /** Reject the request with a 413 instead of returning outputs larger than this many bytes. */
+    maxBytes?: number;
+};
+
+/**
  * Response format for getting detailed execution result.
  */
 type GetExecutionDetailResponse = ExecutionDetail;
@@ -181,10 +189,17 @@ export class Executions {
      * Get detailed result of a specific execution.
      * @param scenarioId The scenario ID the execution belongs to
      * @param executionId The unique ID of the execution to retrieve
+     * @param options Optional parameters, e.g. a byte budget for the returned outputs
      * @returns Promise with the detailed execution result
      */
-    async getDetail(scenarioId: number, executionId: string): Promise<ExecutionDetail> {
-        return await this.#fetch<GetExecutionDetailResponse>(`/scenarios/${scenarioId}/executions/${executionId}`);
+    async getDetail(
+        scenarioId: number,
+        executionId: string,
+        options?: GetExecutionDetailOptions,
+    ): Promise<ExecutionDetail> {
+        return await this.#fetch<GetExecutionDetailResponse>(`/scenarios/${scenarioId}/executions/${executionId}`, {
+            query: { maxBytes: options?.maxBytes },
+        });
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,13 @@ export type {
     CreateConnectedSystemBody,
     UpdateConnectedSystemBody,
 } from './endpoints/connected-systems.js';
-export type { Execution, ExecutionDetail, Executions, ListExecutionsOptions } from './endpoints/executions.js';
+export type {
+    Execution,
+    ExecutionDetail,
+    Executions,
+    ListExecutionsOptions,
+    GetExecutionDetailOptions,
+} from './endpoints/executions.js';
 export type {
     Folder,
     Folders,

--- a/test/executions.spec.ts
+++ b/test/executions.spec.ts
@@ -42,6 +42,18 @@ describe('Endpoints: Executions', () => {
             expect(result).toStrictEqual(executionsGetDetailMock);
         });
 
+        it('Should get execution detail with maxBytes', async () => {
+            mockFetch(
+                'GET https://make.local/api/v2/scenarios/123456/executions/cc1c49323b344687a324888762206003?maxBytes=512000',
+                executionsGetDetailMock,
+            );
+
+            const result = await make.executions.getDetail(123456, 'cc1c49323b344687a324888762206003', {
+                maxBytes: 512000,
+            });
+            expect(result).toStrictEqual(executionsGetDetailMock);
+        });
+
         it('Should list executions for incomplete execution', async () => {
             mockFetch('GET https://make.local/api/v2/dlqs/123456/logs', executionsDlqListMock);
 


### PR DESCRIPTION
## Summary
- Adds an optional `maxBytes` byte budget to `executions.getDetail`, passed through as a query param, so callers can ask the API to reject oversized execution outputs (413) instead of returning them.
- Bumps package version to 1.6.10 for release.

Part of the fix for the `mcp-server-host` OOM incident: a byte budget is threaded through the whole read chain (`mono` → `imt-web-api` → this SDK → `mcp-server-host`), where each layer either delivers the full result or refuses with a distinct "too large" error.

Jira: https://make.atlassian.net/browse/WM-4622

## Test plan
- [x] `npm run lint` (tsc + eslint) passes
- [x] `npx prettier --check` passes
- [x] `npm test` — 331/331 passing, 100% coverage on `executions.ts`
- [x] `npm run build` succeeds