### PR TITLE
feat(scenario-labels): add labels_list endpoint and MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ const make = new Make('your-api-key', 'eu2.make.com', {
 - **Data Structures** - Data schemas and formats
 - **Executions** - Scenario execution history
 - **Folders** - Scenario categorization
+- **Scenario Labels** - Team-scoped tags assignable to scenarios
 - **Functions** - Custom JavaScript functions for scenarios
 - **Hooks** - Webhooks and mailhooks for external integrations
 - **Incomplete Executions** - Failed or incomplete scenario runs
@@ -213,6 +214,7 @@ All tools are organized into the following categories:
 - `hooks`
 - `incomplete-executions`
 - `keys`
+- `labels`
 - `on-prem-agent`
 - `organizations`
 - `private-spaces`

--- a/src/endpoints/scenario-labels.tools.ts
+++ b/src/endpoints/scenario-labels.tools.ts
@@ -1,0 +1,31 @@
+import type { Make } from '../make.js';
+import type { MakeTool } from '../tools.js';
+
+export const tools: MakeTool[] = [
+    {
+        name: 'labels_list',
+        title: 'List scenario labels',
+        description:
+            "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, call users_me to learn it. Requires the scenario-labels feature to be enabled on the environment (fails with an explanatory error otherwise).",
+        category: 'labels',
+        scope: 'scenarios:read',
+        scopeId: 'teamId',
+        identifier: 'teamId',
+        annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
+        },
+        inputSchema: {
+            type: 'object',
+            properties: {
+                teamId: { type: 'number', description: 'The team ID to list scenario labels for' },
+            },
+            required: ['teamId'],
+        },
+        examples: [{ teamId: 5 }],
+        execute: async (make: Make, args: { teamId: number }) => {
+            return await make.scenarioLabels.list(args.teamId);
+        },
+    },
+];

--- a/src/endpoints/scenario-labels.tools.ts
+++ b/src/endpoints/scenario-labels.tools.ts
@@ -6,7 +6,7 @@ export const tools: MakeTool[] = [
         name: 'labels_list',
         title: 'List scenario labels',
         description:
-            "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, call users_me to learn it. Requires the scenario-labels feature to be enabled on the environment (fails with an explanatory error otherwise).",
+            "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, call users_me to learn it.",
         category: 'labels',
         scope: 'scenarios:read',
         scopeId: 'teamId',

--- a/src/endpoints/scenario-labels.ts
+++ b/src/endpoints/scenario-labels.ts
@@ -1,0 +1,78 @@
+import type { FetchFunction } from '../types.js';
+
+/**
+ * Colour of a scenario label, one of the fixed palette values supported by the API.
+ */
+export type ScenarioLabelColour = 'white' | 'neutral' | 'brand' | 'info' | 'success' | 'warning' | 'danger' | 'pink';
+
+/**
+ * Represents a scenario label in Make.
+ * Scenario labels are team-scoped tags with a many-to-many relationship to scenarios:
+ * a scenario can carry any number of labels and a label can be assigned to any number
+ * of the team's scenarios. Labels are independent of scenario folders.
+ */
+export type ScenarioLabel = {
+    /** Unique identifier of the label */
+    id: number;
+    /** Name of the label */
+    name: string;
+    /** Colour of the label */
+    colour: ScenarioLabelColour;
+    /** Scope of the label. Currently always `team` */
+    scope: 'team';
+    /** ID of the team that owns the label */
+    teamId: number | null;
+    /** Optional human-readable description of the label, or `null` when not set */
+    description: string | null;
+    /** ID of the user who created the label, or `null` when unavailable */
+    createdBy: number | null;
+    /** Timestamp when the label was created */
+    created: string;
+    /** Timestamp when the label was last updated, or `null` when never updated */
+    updated: string | null;
+};
+
+/**
+ * Catalog item shape returned when listing a team's scenario labels: the label plus the
+ * aggregate number of non-trashed scenarios currently carrying it. The aggregate is
+ * list-only — single-label responses return a plain {@link ScenarioLabel}.
+ */
+export type ScenarioLabelWithCount = ScenarioLabel & {
+    /** Number of the team's non-trashed scenarios carrying this label */
+    scenariosCount: number;
+};
+
+/**
+ * Response format for listing scenario labels.
+ */
+type ListScenarioLabelsResponse = {
+    /** The team's scenario label catalog */
+    labels: ScenarioLabelWithCount[];
+};
+
+/**
+ * Class providing methods for working with scenario labels.
+ *
+ * Scenario labels require the scenario-labels feature to be enabled on the environment;
+ * requests fail with an explanatory error where it is not.
+ */
+export class ScenarioLabels {
+    readonly #fetch: FetchFunction;
+
+    /** @internal */
+    constructor(fetch: FetchFunction) {
+        this.#fetch = fetch;
+    }
+
+    /**
+     * List a team's scenario label catalog, including how many scenarios carry each label.
+     * @param teamId The team ID to list scenario labels for
+     * @returns The team's scenario labels with their scenario counts
+     */
+    async list(teamId: number): Promise<ScenarioLabelWithCount[]> {
+        const response = await this.#fetch<ListScenarioLabelsResponse>('/scenario-labels', {
+            query: { teamId },
+        });
+        return response.labels;
+    }
+}

--- a/src/endpoints/scenario-labels.ts
+++ b/src/endpoints/scenario-labels.ts
@@ -52,9 +52,6 @@ type ListScenarioLabelsResponse = {
 
 /**
  * Class providing methods for working with scenario labels.
- *
- * Scenario labels require the scenario-labels feature to be enabled on the environment;
- * requests fail with an explanatory error where it is not.
  */
 export class ScenarioLabels {
     readonly #fetch: FetchFunction;

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,12 @@ export type {
     UpdateFolderBody,
 } from './endpoints/folders.js';
 export type {
+    ScenarioLabel,
+    ScenarioLabelColour,
+    ScenarioLabels,
+    ScenarioLabelWithCount,
+} from './endpoints/scenario-labels.js';
+export type {
     Function,
     Functions,
     FunctionHistory,

--- a/src/make.ts
+++ b/src/make.ts
@@ -5,6 +5,7 @@ import { Blueprints } from './endpoints/blueprints.js';
 import { Executions } from './endpoints/executions.js';
 import { DataStructures } from './endpoints/data-structures.js';
 import { Folders } from './endpoints/folders.js';
+import { ScenarioLabels } from './endpoints/scenario-labels.js';
 import { Hooks } from './endpoints/hooks.js';
 import { Teams } from './endpoints/teams.js';
 import { IncompleteExecutions } from './endpoints/incomplete-executions.js';
@@ -110,6 +111,12 @@ export class Make {
      * Folders help organize scenarios
      */
     public readonly folders: Folders;
+
+    /**
+     * Access to scenario label-related endpoints
+     * Scenario labels are team-scoped tags with a many-to-many relationship to scenarios
+     */
+    public readonly scenarioLabels: ScenarioLabels;
 
     /**
      * Access to webhook-related endpoints
@@ -297,6 +304,7 @@ export class Make {
         this.executions = new Executions(this.fetch.bind(this));
         this.dataStructures = new DataStructures(this.fetch.bind(this));
         this.folders = new Folders(this.fetch.bind(this));
+        this.scenarioLabels = new ScenarioLabels(this.fetch.bind(this));
         this.hooks = new Hooks(this.fetch.bind(this));
         this.teams = new Teams(this.fetch.bind(this));
         this.incompleteExecutions = new IncompleteExecutions(this.fetch.bind(this));

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -23,6 +23,7 @@ import { tools as HooksTools } from './endpoints/hooks.tools.js';
 import { tools as DevicesTools } from './endpoints/devices.tools.js';
 import { tools as KeysTools } from './endpoints/keys.tools.js';
 import { tools as FoldersTools } from './endpoints/folders.tools.js';
+import { tools as ScenarioLabelsTools } from './endpoints/scenario-labels.tools.js';
 import { tools as IncompleteExecutionsTools } from './endpoints/incomplete-executions.tools.js';
 import { tools as DataStructuresTools } from './endpoints/data-structures.tools.js';
 import { tools as EnumsTools } from './endpoints/enums.tools.js';
@@ -221,6 +222,7 @@ export const MakeTools = [
     ...ExecutionsTools,
     ...IncompleteExecutionsTools,
     ...FoldersTools,
+    ...ScenarioLabelsTools,
     ...FunctionsTools,
     ...HooksTools,
     ...DevicesTools,

--- a/test/mocks/scenario-labels/list.json
+++ b/test/mocks/scenario-labels/list.json
@@ -1,0 +1,28 @@
+{
+    "labels": [
+        {
+            "id": 1,
+            "name": "critical",
+            "colour": "danger",
+            "scope": "team",
+            "teamId": 5,
+            "description": "Scenarios that must not fail silently",
+            "createdBy": 986,
+            "created": "2026-08-01T09:30:00.000Z",
+            "updated": null,
+            "scenariosCount": 4
+        },
+        {
+            "id": 2,
+            "name": "billing",
+            "colour": "info",
+            "scope": "team",
+            "teamId": 5,
+            "description": null,
+            "createdBy": 986,
+            "created": "2026-08-02T10:00:00.000Z",
+            "updated": "2026-08-10T12:00:00.000Z",
+            "scenariosCount": 0
+        }
+    ]
+}

--- a/test/scenario-labels-tools.spec.ts
+++ b/test/scenario-labels-tools.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+import { Make } from '../src/make.js';
+import { MakeTools } from '../src/tools.js';
+import { mockFetch } from './test.utils.js';
+
+import * as listMock from './mocks/scenario-labels/list.json';
+
+const MAKE_API_KEY = 'api-key';
+const MAKE_ZONE = 'make.local';
+const TEAM_ID = 5;
+
+function getTool(name: string) {
+    const tool = MakeTools.find(entry => entry.name === name);
+    if (!tool) {
+        throw new Error(`Missing MCP tool: ${name}`);
+    }
+    return tool;
+}
+
+describe('MCP tools: labels', () => {
+    const make = new Make(MAKE_API_KEY, MAKE_ZONE);
+
+    it('Should execute labels_list', async () => {
+        mockFetch(`GET https://make.local/api/v2/scenario-labels?teamId=${TEAM_ID}`, listMock);
+
+        const tool = getTool('labels_list');
+        const result = await tool.execute(make, { teamId: TEAM_ID });
+
+        expect(result).toStrictEqual(listMock.labels);
+    });
+
+    it('Should declare labels_list as a read-only scenarios:read tool scoped by teamId', () => {
+        const tool = getTool('labels_list');
+
+        expect(tool.category).toBe('labels');
+        expect(tool.scope).toBe('scenarios:read');
+        expect(tool.scopeId).toBe('teamId');
+        expect(tool.inputSchema.required).toStrictEqual(['teamId']);
+        expect(tool.annotations?.readOnlyHint).toBe(true);
+    });
+});

--- a/test/scenario-labels.spec.ts
+++ b/test/scenario-labels.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+import { Make } from '../src/make.js';
+import { mockFetch } from './test.utils.js';
+
+import * as listMock from './mocks/scenario-labels/list.json';
+
+const MAKE_API_KEY = 'api-key';
+const MAKE_ZONE = 'make.local';
+const TEAM_ID = 5;
+
+describe('Endpoints: ScenarioLabels', () => {
+    const make = new Make(MAKE_API_KEY, MAKE_ZONE);
+
+    it('Should list scenario labels for a team', async () => {
+        mockFetch(`GET https://make.local/api/v2/scenario-labels?teamId=${TEAM_ID}`, listMock);
+
+        const result = await make.scenarioLabels.list(TEAM_ID);
+        expect(result).toStrictEqual(listMock.labels);
+    });
+});


### PR DESCRIPTION
https://make.atlassian.net/browse/BAR-3815

Tracer slice for Scenario Labels in Make MCP tools (parent: [BAR-3814](https://make.atlassian.net/browse/BAR-3814)) — the thinnest complete path through every layer, mirroring the custom-properties precedent (#76). Follow-up slices add catalog mutations, assignment, and scenario-list filters.

## What

- **`ScenarioLabels` endpoint module** — `make.scenarioLabels.list(teamId)` → `GET /scenario-labels?teamId=…`, returning the team's label catalog with `scenariosCount` per label
- **`labels_list` MCP tool** — category `labels`, `scope: scenarios:read`, `scopeId: teamId`, `readOnlyHint`; description covers team-scoping and the `users_me` teamId-discovery hint
- Wiring: `Make` client property, `index.ts` type exports, `tools.ts` registration, README rows
- Tests: unit spec (exact request URL + envelope unwrap) and tools spec (execute delegation + scope/schema metadata), with realistic mock data

## Notes for review

- **No `cols`/`pg` options on `list` — intentional.** The backend list validation accepts only `teamId` (verified in imt-web-api `scenario-labels` controller/validations); offering column selection would be dead API surface.
- Response envelopes verified against backend source: list → `{ labels }` (single-label endpoints use `{ label }` — relevant for follow-up slices).
- Scenario Labels are GA — the legacy `IS_SCENARIO_LABELS_ENABLED` gate is on everywhere and its router middleware is being removed, so the tool description intentionally does not mention it.
- **No integration test in this PR by design** — the live lifecycle test is a dedicated follow-up slice (BAR-3819) gating the release.

## Verification

- `npx jest test/scenario-labels.spec.ts test/scenario-labels-tools.spec.ts` — 3 tests pass
- `npm test` — 48 suites / 334 tests pass
- `npm run lint` (tsc + eslint) — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

[BAR-3814]: https://make.atlassian.net/browse/BAR-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ