### PR TITLE
feat(scenarios): add folder/label list filters and labels column typing

### DIFF
--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -122,7 +122,8 @@ export const tools: MakeTool[] = [
     {
         name: 'scenarios_list',
         title: 'List scenarios',
-        description: 'List all scenarios for a team.',
+        description:
+            'List all scenarios for a team. Results can be narrowed to one folder (optionally including its subfolders) and/or to scenarios carrying at least one of the given scenario labels. Returned scenarios include their assigned labels.',
         category: 'scenarios',
         scope: 'scenarios:read',
         scopeId: 'teamId',
@@ -136,12 +137,31 @@ export const tools: MakeTool[] = [
             type: 'object',
             properties: {
                 teamId: { type: 'number', description: 'The team ID to filter scenarios by' },
+                folderId: { type: 'number', description: 'Only return scenarios placed in this folder' },
+                includeSubfolders: {
+                    type: 'boolean',
+                    description: 'When filtering by folderId, also include scenarios placed in its subfolders',
+                },
+                labelIds: {
+                    type: 'array',
+                    items: { type: 'number' },
+                    description:
+                        'Only return scenarios carrying at least one of these scenario label IDs. Use labels_list to discover label IDs.',
+                },
             },
             required: ['teamId'],
         },
-        examples: [{ teamId: 5 }],
-        execute: async (make: Make, args: { teamId: number }) => {
-            return await make.scenarios.list(args.teamId, { cols: ['*'] });
+        examples: [
+            { teamId: 5 },
+            { teamId: 5, folderId: 1576, includeSubfolders: true },
+            { teamId: 5, labelIds: [42, 43] },
+        ],
+        execute: async (
+            make: Make,
+            args: { teamId: number; folderId?: number; includeSubfolders?: boolean; labelIds?: number[] },
+        ) => {
+            const { teamId, ...filters } = args;
+            return await make.scenarios.list(teamId, { ...filters, cols: ['*'] });
         },
     },
     {

--- a/src/endpoints/scenarios.ts
+++ b/src/endpoints/scenarios.ts
@@ -1,6 +1,7 @@
 import type { FetchFunction, JSONValue, Pagination, PickColumns } from '../types.js';
 import { Blueprint } from './blueprints.js';
 import type { DataStructureField } from './data-structures.js';
+import type { ScenarioLabel } from './scenario-labels.js';
 import { ScenarioCustomProperties } from './scenario-custom-properties.js';
 
 /**
@@ -20,6 +21,10 @@ export type Scenario = {
     teamId: number;
     /** ID of the folder containing the scenario */
     folderId: number;
+    /** Slash-separated path of the containing folder (e.g. `CRM/cleanup`), or `null` when the scenario is not in a folder. Returned when requested via `cols` (included by `*`) */
+    folderPath?: string | null;
+    /** Scenario labels assigned to the scenario, sorted by name (empty array when unassigned). Returned when requested via `cols` (included by `*`) */
+    labels?: ScenarioLabel[];
     /** List of packages/apps used in the scenario */
     usedPackages: string[];
     /** Scheduling configuration for the scenario */
@@ -108,6 +113,12 @@ export type ListScenariosOptions<C extends keyof Scenario = never> = {
     cols?: C[] | ['*'];
     /** Pagination options */
     pg?: Partial<Pagination<Scenario>>;
+    /** Only return scenarios placed in this folder */
+    folderId?: number;
+    /** When filtering by `folderId`, also include scenarios placed in its subfolders */
+    includeSubfolders?: boolean;
+    /** Only return scenarios carrying at least one of the given scenario label IDs */
+    labelIds?: number[];
 };
 
 /**
@@ -391,6 +402,9 @@ export class Scenarios {
             await this.#fetch<ListScenariosResponse<C>>('/scenarios', {
                 query: {
                     teamId,
+                    folderId: options?.folderId,
+                    includeSubfolders: options?.includeSubfolders,
+                    labelIds: options?.labelIds,
                     cols: options?.cols,
                     pg: options?.pg,
                 },
@@ -412,6 +426,9 @@ export class Scenarios {
             await this.#fetch<ListScenariosResponse<C>>('/scenarios', {
                 query: {
                     organizationId,
+                    folderId: options?.folderId,
+                    includeSubfolders: options?.includeSubfolders,
+                    labelIds: options?.labelIds,
                     cols: options?.cols,
                     pg: options?.pg,
                 },

--- a/test/scenarios-tools.spec.ts
+++ b/test/scenarios-tools.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from '@jest/globals';
+import { Make } from '../src/make.js';
+import { MakeTools } from '../src/tools.js';
+import { mockFetch } from './test.utils.js';
+
+import * as scenariosMock from './mocks/scenarios/list.json';
+
+const MAKE_API_KEY = 'api-key';
+const MAKE_ZONE = 'make.local';
+const TEAM_ID = 18;
+
+function getTool(name: string) {
+    const tool = MakeTools.find(entry => entry.name === name);
+    if (!tool) {
+        throw new Error(`Missing MCP tool: ${name}`);
+    }
+    return tool;
+}
+
+describe('MCP tools: scenarios', () => {
+    const make = new Make(MAKE_API_KEY, MAKE_ZONE);
+
+    it('Should execute scenarios_list without filters (unchanged default request)', async () => {
+        mockFetch(`GET https://make.local/api/v2/scenarios?teamId=${TEAM_ID}&cols%5B%5D=*`, scenariosMock);
+
+        const tool = getTool('scenarios_list');
+        const result = await tool.execute(make, { teamId: TEAM_ID });
+
+        expect(result).toStrictEqual(scenariosMock.scenarios);
+    });
+
+    it('Should execute scenarios_list with folder and label filters', async () => {
+        mockFetch(
+            `GET https://make.local/api/v2/scenarios?teamId=${TEAM_ID}&folderId=123&includeSubfolders=true&labelIds%5B%5D=7&labelIds%5B%5D=9&cols%5B%5D=*`,
+            scenariosMock,
+        );
+
+        const tool = getTool('scenarios_list');
+        const result = await tool.execute(make, {
+            teamId: TEAM_ID,
+            folderId: 123,
+            includeSubfolders: true,
+            labelIds: [7, 9],
+        });
+
+        expect(result).toStrictEqual(scenariosMock.scenarios);
+    });
+
+    it('Should declare the scenarios_list filter parameters as optional', () => {
+        const tool = getTool('scenarios_list');
+
+        expect(tool.inputSchema.required).toStrictEqual(['teamId']);
+        expect(Object.keys(tool.inputSchema.properties ?? {})).toStrictEqual([
+            'teamId',
+            'folderId',
+            'includeSubfolders',
+            'labelIds',
+        ]);
+        expect(tool.inputSchema.properties?.labelIds?.items?.type).toBe('number');
+    });
+});

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -41,6 +41,30 @@ describe('Endpoints: Scenarios', () => {
             expect(result).toStrictEqual(scenariosMock.scenarios);
         });
 
+        it('Should list scenarios filtered by folder, subfolders and labels', async () => {
+            mockFetch(
+                'GET https://make.local/api/v2/scenarios?teamId=18&folderId=123&includeSubfolders=true&labelIds%5B%5D=7&labelIds%5B%5D=9',
+                scenariosMock,
+            );
+
+            const result = await make.scenarios.list(18, {
+                folderId: 123,
+                includeSubfolders: true,
+                labelIds: [7, 9],
+            });
+            expect(result).toStrictEqual(scenariosMock.scenarios);
+        });
+
+        it('Should list scenarios in organization filtered by labels', async () => {
+            mockFetch(
+                'GET https://make.local/api/v2/scenarios?organizationId=18&labelIds%5B%5D=7',
+                scenariosMock,
+            );
+
+            const result = await make.scenarios.listInOrganization(18, { labelIds: [7] });
+            expect(result).toStrictEqual(scenariosMock.scenarios);
+        });
+
         it('Should get scenario interface', async () => {
             mockFetch('GET https://make.local/api/v2/scenarios/18/interface', scenarioInterfaceMock);
 


### PR DESCRIPTION
https://make.atlassian.net/browse/BAR-3816

Third slice of Scenario Labels in Make MCP tools ([BAR-3814](https://make.atlassian.net/browse/BAR-3814)). Makes organization *queryable*: without this, agents can build folder trees and (after #84) assign labels, but can't ask "what's in this folder?" or "which scenarios carry this label?" without dumping the whole team list.

## What

- **`ListScenariosOptions`** gains `folderId`, `includeSubfolders`, `labelIds` — passed through by both `scenarios.list()` and `scenarios.listInOrganization()`
- **`Scenario` type** gains `labels?: ScenarioLabel[]` and `folderPath?: string | null` — virtual columns requested via `cols` and included by `cols=['*']`
- **`scenarios_list` tool** exposes the three filters (with a `labels_list` cross-reference for label-ID discovery) and documents that returned scenarios include their labels
- Tests: composed-filter and org-wide-filter request assertions (exact `labelIds[]` bracket encoding), a new `scenarios-tools` spec (default request unchanged, filtered request, schema shape). The two pre-existing list specs pass **unmodified** — the filterless request is byte-identical (non-breaking).

## Contract notes (verified against imt-web-api source)

- `labelIds` filtering is **OR semantics** — scenarios carrying *at least one* of the given labels (`scenarios_get.sql`: `EXISTS (… label_id = ANY(…))`). Documented as such in JSDoc and tool description.
- `includeSubfolders` composes with `folderId` (subtree temp-table in the procedure); meaningless without it.
- `cols=['*']` expands server-side to *all allowed columns*, which includes the `labels` embed and `folderPath` — so the `scenarios_list` tool (which already sends `['*']`) has been returning labels on GA environments; this PR adds the typing and the filters.
- Known pre-existing typing wart: `PickColumns` wraps explicit selections in `NonNullable`, so `cols: ['folderPath']` types as `string` though `null` is a real value (uncategorized scenario). The `['*']` path types correctly. Affects every nullable column in the repo; not addressed here.
- The backend's undocumented `folder=none` (Uncategorized) magic value is intentionally **not** exposed — it's deliberately absent from the public OpenAPI.

## Verification

- `npx jest test/scenarios.spec.ts test/scenarios-tools.spec.ts` — 17 tests pass
- `npm test` — 339 tests pass (default-request regressions included)
- `npm run lint` (tsc + eslint) — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

[BAR-3814]: https://make.atlassian.net/browse/BAR-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ