### PR TITLE
fix(tools): correct team-discovery and access-denied guidance in tool contracts

### DIFF
--- a/src/endpoints/folders.tools.ts
+++ b/src/endpoints/folders.tools.ts
@@ -6,7 +6,7 @@ export const tools: MakeTool[] = [
         name: 'folders_list',
         title: 'List folders',
         description:
-            'List scenario folders for a team. If you do not know the teamId, find it via organizations_list (each organization lists its teams) or teams_list, or ask the user — never guess ids.',
+            'List scenario folders for a team. If you do not know the teamId, find it via organizations_list (each organization lists its teams) or teams_list, or ask the user — never guess IDs.',
         category: 'folders',
         scope: 'scenarios:read',
         scopeId: 'teamId',

--- a/src/endpoints/folders.tools.ts
+++ b/src/endpoints/folders.tools.ts
@@ -5,7 +5,8 @@ export const tools: MakeTool[] = [
     {
         name: 'folders_list',
         title: 'List folders',
-        description: 'List scenario folders for a team. If you do not know the teamId, call users_me to learn it.',
+        description:
+            'List scenario folders for a team. If you do not know the teamId, find it via organizations_list (each organization lists its teams) or teams_list, or ask the user — never guess ids.',
         category: 'folders',
         scope: 'scenarios:read',
         scopeId: 'teamId',

--- a/src/endpoints/scenario-labels.tools.ts
+++ b/src/endpoints/scenario-labels.tools.ts
@@ -6,7 +6,7 @@ export const tools: MakeTool[] = [
         name: 'labels_list',
         title: 'List scenario labels',
         description:
-            "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, call users_me to learn it.",
+            "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, find it via organizations_list (each organization lists its teams) or teams_list, or ask the user — never guess ids.",
         category: 'labels',
         scope: 'scenarios:read',
         scopeId: 'teamId',

--- a/src/endpoints/scenario-labels.tools.ts
+++ b/src/endpoints/scenario-labels.tools.ts
@@ -6,7 +6,7 @@ export const tools: MakeTool[] = [
         name: 'labels_list',
         title: 'List scenario labels',
         description:
-            "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, find it via organizations_list (each organization lists its teams) or teams_list, or ask the user — never guess ids.",
+            "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, find it via organizations_list (each organization lists its teams) or teams_list, or ask the user — never guess IDs.",
         category: 'labels',
         scope: 'scenarios:read',
         scopeId: 'teamId',

--- a/src/endpoints/teams.tools.ts
+++ b/src/endpoints/teams.tools.ts
@@ -6,7 +6,7 @@ export const tools: MakeTool[] = [
         name: 'teams_list',
         title: 'List teams',
         description:
-            "List the teams of an organization. Requires an organizationId — get it from organizations_list or users_me. 'Access denied' means your token is team-scoped and cannot list teams: call users_me to learn your teamId and use teams_get instead.",
+            "List the teams of an organization. Requires an organizationId — get it from organizations_list, whose response also includes each organization's teams (id and name). Results include only teams you can view. 'Access denied' usually means the token lacks the teams:read scope — ask the user to re-authorize with it.",
         category: 'teams',
         scope: 'teams:read',
         scopeId: 'organizationId',

--- a/src/endpoints/teams.tools.ts
+++ b/src/endpoints/teams.tools.ts
@@ -6,7 +6,7 @@ export const tools: MakeTool[] = [
         name: 'teams_list',
         title: 'List teams',
         description:
-            "List the teams of an organization. Requires an organizationId — get it from organizations_list, whose response also includes each organization's teams (id and name). Results include only teams you can view. 'Access denied' usually means the token lacks the teams:read scope — ask the user to re-authorize with it.",
+            "List the teams of an organization. Requires an organizationId — get it from organizations_list, whose response also includes each organization's teams (id and name). Results include only teams you can view. 'Access denied' usually means the token lacks the teams:read scope — ask the user to re-authorize and grant teams:read.",
         category: 'teams',
         scope: 'teams:read',
         scopeId: 'organizationId',


### PR DESCRIPTION
## Problem

Three tool descriptions (`teams_list`, `folders_list`, `labels_list`) tell agents to "call users_me to learn your teamId". `users_me` returns only profile fields — the `User` type has no team or organization data — so agents hit a dead end and fall back to guessing ids (observed in live agent testing against the Make MCP server).

`teams_list`'s access-denied guidance was also inaccurate: web-api gates `GET /teams*` behind the `teams:read` scope (`imt.js`), so "Access denied" indicates a missing scope rather than a team-scoped token — and `teams_get` sits behind the same gate, so pointing at it as a fallback couldn't work. Non-membership surfaces differently (verified live: `Insufficient rights, admin permission "organization view" is needed`), and within an accessible organization results are membership-filtered — neither produces "Access denied".

## Fix

Point team discovery at `organizations_list` (whose response embeds each organization's teams with ids and names — the tool requests `cols: ['*']`, so the field is actually returned; verified live) and `teams_list`, with an ask-the-user fallback for tokens whose scopes hide those tools from the listing (observed live: a connection without `scenarios:read` never sees `folders_list`/`labels_list`).

Describe the actual access-denied cause (missing `teams:read` — re-authorize) and the membership filtering.

Description-only change; no behavior or schema changes.