### PR TITLE
test(scenario-labels): add live integration test for the label lifecycle

### DIFF
--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -295,7 +295,11 @@ export const tools: MakeTool[] = [
                     maxLength: 240,
                     description: 'New description for the scenario (maximum 240 characters)',
                 },
-                folderId: { type: 'number', description: 'New folder ID for the scenario' },
+                folderId: {
+                    oneOf: [{ type: 'number' }, { type: 'null' }],
+                    description:
+                        'New folder ID for the scenario. Use null to move the scenario out of its folder (Uncategorized); omit to leave unchanged.',
+                },
                 scheduling: schedulingInputSchema,
                 blueprint: blueprintInputSchema,
                 confirmed: {
@@ -318,7 +322,7 @@ export const tools: MakeTool[] = [
                 scenarioId: number;
                 name?: string;
                 description?: string;
-                folderId?: number;
+                folderId?: number | null;
                 scheduling?: Scheduling;
                 blueprint?: Blueprint;
                 confirmed?: boolean;

--- a/src/endpoints/scenarios.ts
+++ b/src/endpoints/scenarios.ts
@@ -19,8 +19,8 @@ export type Scenario = {
     description: string;
     /** ID of the team that owns the scenario */
     teamId: number;
-    /** ID of the folder containing the scenario */
-    folderId: number;
+    /** ID of the folder containing the scenario, or `null` when the scenario is not in a folder */
+    folderId: number | null;
     /** Slash-separated path of the containing folder (e.g. `CRM/cleanup`), or `null` when the scenario is not in a folder. Returned when requested via `cols` (included by `*`) */
     folderPath?: string | null;
     /** Scenario labels assigned to the scenario, sorted by name (empty array when unassigned). Returned when requested via `cols` (included by `*`) */
@@ -245,8 +245,8 @@ export type UpdateScenarioBody = {
     name?: string;
     /** New description for the scenario */
     description?: string;
-    /** New folder ID for the scenario */
-    folderId?: number;
+    /** New folder ID for the scenario. Use `null` to move the scenario out of its folder (Uncategorized); omit to leave unchanged */
+    folderId?: number | null;
     /** Updated scheduling configuration */
     scheduling?: Scheduling | string;
     /** Updated blueprint configuration */

--- a/test/scenario-labels.integration.test.ts
+++ b/test/scenario-labels.integration.test.ts
@@ -1,0 +1,100 @@
+import 'dotenv/config';
+import { afterAll, describe, expect, it } from '@jest/globals';
+import { Make } from '../src/make.js';
+
+const MAKE_API_KEY = String(process.env.MAKE_API_KEY || '');
+const MAKE_ZONE = String(process.env.MAKE_ZONE || '');
+const MAKE_TEAM = Number(process.env.MAKE_TEAM || 0);
+
+describe('Integration: ScenarioLabels', () => {
+    const make = new Make(MAKE_API_KEY, MAKE_ZONE);
+
+    let labelId: number | undefined;
+    let scenarioId: number | undefined;
+
+    // Self-cleaning even when an assertion fails mid-lifecycle: deleting the label
+    // cascade-removes any remaining assignment, and both deletes tolerate the entity
+    // already being gone (errors are swallowed on purpose — cleanup must not mask
+    // the original test failure).
+    afterAll(async () => {
+        if (scenarioId) {
+            await make.scenarios.delete(scenarioId).catch(() => undefined);
+        }
+        if (labelId) {
+            await make.scenarioLabels.delete(labelId).catch(() => undefined);
+        }
+    });
+
+    it('Should create a label', async () => {
+        const label = await make.scenarioLabels.create({
+            teamId: MAKE_TEAM,
+            name: `it-label-${Date.now()}`.slice(0, 30),
+            colour: 'info',
+            description: 'SDK integration test label',
+        });
+
+        expect(label.id).toBeDefined();
+        expect(label.teamId).toBe(MAKE_TEAM);
+        expect(label.scope).toBe('team');
+        expect(label.colour).toBe('info');
+        labelId = label.id;
+    });
+
+    it('Should list the catalog including the created label with a zero count', async () => {
+        const labels = await make.scenarioLabels.list(MAKE_TEAM);
+
+        const created = labels.find(label => label.id === labelId);
+        expect(created).toBeDefined();
+        expect(created?.scenariosCount).toBe(0);
+    });
+
+    it('Should update the label and clear its description with null', async () => {
+        const renamed = await make.scenarioLabels.update(labelId!, { colour: 'warning' });
+        expect(renamed.colour).toBe('warning');
+
+        const cleared = await make.scenarioLabels.update(labelId!, { description: null });
+        expect(cleared.description).toBeNull();
+    });
+
+    it('Should create a scenario and assign the label to it', async () => {
+        const scenario = await make.scenarios.create({
+            teamId: MAKE_TEAM,
+            scheduling: '{"type":"on-demand"}',
+            blueprint: `{"flow":[],"metadata":{},"name":"Label IT ${Date.now()}"}`,
+        });
+        expect(scenario.id).toBeDefined();
+        scenarioId = scenario.id;
+
+        await make.scenarioLabels.assign(labelId!, scenarioId!);
+    });
+
+    it('Should find the scenario via the labelIds filter, with the labels column populated', async () => {
+        const scenarios = await make.scenarios.list(MAKE_TEAM, { labelIds: [labelId!], cols: ['*'] });
+
+        const row = scenarios.find(scenario => scenario.id === scenarioId);
+        expect(row).toBeDefined();
+        expect(row?.labels?.some(label => label.id === labelId)).toBe(true);
+    });
+
+    it('Should reflect the assignment in the catalog count', async () => {
+        const labels = await make.scenarioLabels.list(MAKE_TEAM);
+        expect(labels.find(label => label.id === labelId)?.scenariosCount).toBe(1);
+    });
+
+    it('Should unassign idempotently and drop the scenario from the filtered list', async () => {
+        await make.scenarioLabels.unassign(labelId!, scenarioId!);
+        // Repeat unassign must succeed without changes (verified idempotency contract).
+        await make.scenarioLabels.unassign(labelId!, scenarioId!);
+
+        const scenarios = await make.scenarios.list(MAKE_TEAM, { labelIds: [labelId!] });
+        expect(scenarios.some(scenario => scenario.id === scenarioId)).toBe(false);
+    });
+
+    it('Should delete the label and remove it from the catalog', async () => {
+        await make.scenarioLabels.delete(labelId!);
+
+        const labels = await make.scenarioLabels.list(MAKE_TEAM);
+        expect(labels.some(label => label.id === labelId)).toBe(false);
+        labelId = undefined;
+    });
+});

--- a/test/scenario-labels.integration.test.ts
+++ b/test/scenario-labels.integration.test.ts
@@ -6,6 +6,17 @@ const MAKE_API_KEY = String(process.env.MAKE_API_KEY || '');
 const MAKE_ZONE = String(process.env.MAKE_ZONE || '');
 const MAKE_TEAM = Number(process.env.MAKE_TEAM || 0);
 
+/**
+ * Narrows a cross-step entity ID, failing dependent steps loudly (and without sending a
+ * request to a `/undefined` URL) when the step that should have created the entity failed.
+ */
+function requireId(id: number | undefined, entity: string): number {
+    if (id === undefined) {
+        throw new Error(`Precondition failed: ${entity} was not created in an earlier step`);
+    }
+    return id;
+}
+
 describe('Integration: ScenarioLabels', () => {
     const make = new Make(MAKE_API_KEY, MAKE_ZONE);
 
@@ -44,15 +55,19 @@ describe('Integration: ScenarioLabels', () => {
         const labels = await make.scenarioLabels.list(MAKE_TEAM);
 
         const created = labels.find(label => label.id === labelId);
-        expect(created).toBeDefined();
-        expect(created?.scenariosCount).toBe(0);
+        if (!created) {
+            throw new Error('Created label not found in the team catalog');
+        }
+        expect(created.scenariosCount).toBe(0);
     });
 
     it('Should update the label and clear its description with null', async () => {
-        const renamed = await make.scenarioLabels.update(labelId!, { colour: 'warning' });
+        const id = requireId(labelId, 'label');
+
+        const renamed = await make.scenarioLabels.update(id, { colour: 'warning' });
         expect(renamed.colour).toBe('warning');
 
-        const cleared = await make.scenarioLabels.update(labelId!, { description: null });
+        const cleared = await make.scenarioLabels.update(id, { description: null });
         expect(cleared.description).toBeNull();
     });
 
@@ -65,33 +80,49 @@ describe('Integration: ScenarioLabels', () => {
         expect(scenario.id).toBeDefined();
         scenarioId = scenario.id;
 
-        await make.scenarioLabels.assign(labelId!, scenarioId!);
+        await make.scenarioLabels.assign(requireId(labelId, 'label'), requireId(scenarioId, 'scenario'));
     });
 
     it('Should find the scenario via the labelIds filter, with the labels column populated', async () => {
-        const scenarios = await make.scenarios.list(MAKE_TEAM, { labelIds: [labelId!], cols: ['*'] });
+        const scenarios = await make.scenarios.list(MAKE_TEAM, {
+            labelIds: [requireId(labelId, 'label')],
+            cols: ['*'],
+        });
 
         const row = scenarios.find(scenario => scenario.id === scenarioId);
-        expect(row).toBeDefined();
-        expect(row?.labels?.some(label => label.id === labelId)).toBe(true);
+        if (!row) {
+            throw new Error('Assigned scenario was not returned by the labelIds filter');
+        }
+        if (!row.labels) {
+            throw new Error('The labels column is missing on the filtered scenario row');
+        }
+        expect(row.labels.some(label => label.id === labelId)).toBe(true);
     });
 
     it('Should reflect the assignment in the catalog count', async () => {
         const labels = await make.scenarioLabels.list(MAKE_TEAM);
-        expect(labels.find(label => label.id === labelId)?.scenariosCount).toBe(1);
+
+        const assigned = labels.find(label => label.id === labelId);
+        if (!assigned) {
+            throw new Error('Created label not found in the team catalog');
+        }
+        expect(assigned.scenariosCount).toBe(1);
     });
 
     it('Should unassign idempotently and drop the scenario from the filtered list', async () => {
-        await make.scenarioLabels.unassign(labelId!, scenarioId!);
-        // Repeat unassign must succeed without changes (verified idempotency contract).
-        await make.scenarioLabels.unassign(labelId!, scenarioId!);
+        const id = requireId(labelId, 'label');
+        const targetScenarioId = requireId(scenarioId, 'scenario');
 
-        const scenarios = await make.scenarios.list(MAKE_TEAM, { labelIds: [labelId!] });
-        expect(scenarios.some(scenario => scenario.id === scenarioId)).toBe(false);
+        await make.scenarioLabels.unassign(id, targetScenarioId);
+        // Repeat unassign must succeed without changes (verified idempotency contract).
+        await make.scenarioLabels.unassign(id, targetScenarioId);
+
+        const scenarios = await make.scenarios.list(MAKE_TEAM, { labelIds: [id] });
+        expect(scenarios.some(scenario => scenario.id === targetScenarioId)).toBe(false);
     });
 
     it('Should delete the label and remove it from the catalog', async () => {
-        await make.scenarioLabels.delete(labelId!);
+        await make.scenarioLabels.delete(requireId(labelId, 'label'));
 
         const labels = await make.scenarioLabels.list(MAKE_TEAM);
         expect(labels.some(label => label.id === labelId)).toBe(false);

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -195,6 +195,21 @@ describe('Endpoints: Scenarios', () => {
             expect(result).toStrictEqual(scenarioUpdateMock.scenario);
         });
 
+        it('Should move a scenario out of its folder with folderId null', async () => {
+            mockFetch('PATCH https://make.local/api/v2/scenarios/123456', scenarioUpdateMock, req => {
+                expect(req.body).toStrictEqual({
+                    folderId: null,
+                    metadata: {
+                        input_spec: [],
+                        output_spec: [],
+                    },
+                });
+            });
+
+            const result = await make.scenarios.update(123456, { folderId: null });
+            expect(result).toStrictEqual(scenarioUpdateMock.scenario);
+        });
+
         it('Should delete a scenario', async () => {
             mockFetch('DELETE https://make.local/api/v2/scenarios/1399', null);
 


### PR DESCRIPTION
https://make.atlassian.net/browse/BAR-3819

Fourth slice of Scenario Labels in Make MCP tools ([BAR-3814](https://make.atlassian.net/browse/BAR-3814)), following #83/#84/#85 (all merged). Primarily the live-environment reality check that the mock-based specs cannot provide, plus two review follow-ups:

- `bad85b8` — precondition guards in the lifecycle test (review comments on this PR)
- `dd10534` — leftover review comment from #85: `Scenario.folderId` is `number | null` (uncategorized scenarios), and the update path (`UpdateScenarioBody` + `scenarios_update` tool schema) accepts `null` to move a scenario out of its folder — verified against the production web UI's move-to-Uncategorized PATCH; spec added proving `folderId: null` survives serialization.

## What

`test/scenario-labels.integration.test.ts` — the full label lifecycle against a real zone (`test:integration` suite, env-credentialed via `MAKE_API_KEY`/`MAKE_ZONE`/`MAKE_TEAM`, pattern of the custom-properties integration tests):

1. create label (verifies the `{ label }` envelope and field shape live)
2. list catalog (`scenariosCount: 0`)
3. update colour + clear description with `null`
4. create a throwaway on-demand scenario, assign the label
5. `scenarios.list` filtered by `labelIds` with `cols: ['*']` — the key check: real `labelIds[]` query encoding accepted by the server + `labels` embed populated on the row
6. catalog count reflects the assignment
7. unassign **twice** (verifies the documented idempotency contract), filtered list drops the scenario
8. delete label, gone from catalog

Self-cleaning `afterAll` removes the scenario and label even when an assertion fails mid-lifecycle; cleanup errors are swallowed so they can't mask the original failure.

## Live run — PASSED ✅

Executed 2026-08-25 against a staging zone (`eu1.hqrelease.net`): **8/8 steps passed on the first run** (2.8s). Every assumption baked into the unit mocks of #83–#85 is confirmed against the real backend — response envelopes, `labelIds[]` array encoding, the `labels` embed, `description: null` clearing, unassign idempotency, and `scenariosCount` freshness (the one pre-flagged risk did not materialize; the aggregate is immediate). No mock corrections were needed.

## Verification

- Live: `npx jest --runInBand --forceExit --testMatch "**/test/scenario-labels.integration.test.ts"` — 8/8 pass
- `npm run lint` (tsc + eslint) — clean
- `npm test` — unaffected (file correctly excluded from the default testMatch)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

[BAR-3814]: https://make.atlassian.net/browse/BAR-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
