### PR TITLE
chore: bump version to 1.6.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.10",
+    "version": "1.6.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.10",
+            "version": "1.6.11",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.10",
+    "version": "1.6.11",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",


### PR DESCRIPTION
## Summary
- Bump version to 1.6.11 for release.

Changes since v1.6.10:
- [test(scenario-labels): add live integration test for the label lifecycle (](https://github.com/integromat/make-typescript-sdk/commit/75dc7bb77a72d561182420c0fb93390edc72be3a)
- [feat(scenarios): add folder/label list filters and labels column typing (](https://github.com/integromat/make-typescript-sdk/commit/4bd6d90e93a9ef5ffe19ea8f49c398f99c35ffa2)
- [feat(scenario-labels): add label mutations and assignment (CRUD + assign/unassign MCP tools)](https://github.com/integromat/make-typescript-sdk/commit/d69892ebdea57b8cdb3cfcc9ba065b97dab2d4c4)
