### PR TITLE
fix(tools): rename labels tools to scenario-labels for naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ All tools are organized into the following categories:
 - `hooks`
 - `incomplete-executions`
 - `keys`
-- `labels`
+- `scenario-labels`
 - `on-prem-agent`
 - `organizations`
 - `private-spaces`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.11",
+    "version": "1.6.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.11",
+            "version": "1.6.12",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.11",
+    "version": "1.6.12",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",

--- a/src/endpoints/scenario-labels.tools.ts
+++ b/src/endpoints/scenario-labels.tools.ts
@@ -15,11 +15,11 @@ const LABEL_COLOURS: ScenarioLabelColour[] = [
 
 export const tools: MakeTool[] = [
     {
-        name: 'labels_list',
+        name: 'scenario-labels_list',
         title: 'List scenario labels',
         description:
             "List a team's scenario label catalog, including how many scenarios carry each label. Scenario labels are team-scoped tags that can be assigned to scenarios, independent of folders. If you do not know the teamId, find it via organizations_list (each organization lists its teams) or teams_list, or ask the user — never guess IDs.",
-        category: 'labels',
+        category: 'scenario-labels',
         scope: 'scenarios:read',
         scopeId: 'teamId',
         identifier: 'teamId',
@@ -41,11 +41,11 @@ export const tools: MakeTool[] = [
         },
     },
     {
-        name: 'labels_create',
+        name: 'scenario-labels_create',
         title: 'Create scenario label',
         description:
             'Create a new scenario label in a team. Labels are team-scoped tags that can be assigned to scenarios. If you do not know the teamId, call users_me to learn it.',
-        category: 'labels',
+        category: 'scenario-labels',
         scope: 'scenarios:write',
         scopeId: 'teamId',
         identifier: 'teamId',
@@ -78,11 +78,11 @@ export const tools: MakeTool[] = [
         },
     },
     {
-        name: 'labels_update',
+        name: 'scenario-labels_update',
         title: 'Update scenario label',
         description:
             'Update the name, colour, or description of an existing scenario label. Provide at least one property to change; omitted properties are left unchanged. Changes are reflected on every scenario carrying the label.',
-        category: 'labels',
+        category: 'scenario-labels',
         scope: 'scenarios:write',
         scopeId: 'labelId',
         identifier: 'labelId',
@@ -122,11 +122,11 @@ export const tools: MakeTool[] = [
         },
     },
     {
-        name: 'labels_delete',
+        name: 'scenario-labels_delete',
         title: 'Delete scenario label',
         description:
             'Delete a scenario label. The label is removed from the team catalog and unassigned from every scenario carrying it. This cannot be undone.',
-        category: 'labels',
+        category: 'scenario-labels',
         scope: 'scenarios:write',
         scopeId: 'labelId',
         identifier: 'labelId',
@@ -150,11 +150,11 @@ export const tools: MakeTool[] = [
         },
     },
     {
-        name: 'labels_assign',
+        name: 'scenario-labels_assign',
         title: 'Assign scenario label',
         description:
             'Assign a scenario label to a scenario. The label and the scenario must belong to the same team. Assigning an already-assigned label succeeds without changes. To label many scenarios, call this tool once per scenario.',
-        category: 'labels',
+        category: 'scenario-labels',
         scope: 'scenarios:write',
         scopeId: 'labelId',
         identifier: 'labelId',
@@ -180,11 +180,11 @@ export const tools: MakeTool[] = [
         },
     },
     {
-        name: 'labels_unassign',
+        name: 'scenario-labels_unassign',
         title: 'Unassign scenario label',
         description:
             'Remove a scenario label from a scenario. Removing an already-absent assignment succeeds without changes. The label itself stays in the team catalog.',
-        category: 'labels',
+        category: 'scenario-labels',
         scope: 'scenarios:write',
         scopeId: 'labelId',
         identifier: 'labelId',

--- a/src/endpoints/scenarios.tools.ts
+++ b/src/endpoints/scenarios.tools.ts
@@ -146,7 +146,7 @@ export const tools: MakeTool[] = [
                     type: 'array',
                     items: { type: 'number' },
                     description:
-                        'Only return scenarios carrying at least one of these scenario label IDs. Use labels_list to discover label IDs.',
+                        'Only return scenarios carrying at least one of these scenario label IDs. Use scenario-labels_list to discover label IDs.',
                 },
             },
             required: ['teamId'],

--- a/test/scenario-labels-tools.spec.ts
+++ b/test/scenario-labels-tools.spec.ts
@@ -23,75 +23,75 @@ function getTool(name: string) {
     return tool;
 }
 
-describe('MCP tools: labels', () => {
+describe('MCP tools: scenario-labels', () => {
     const make = new Make(MAKE_API_KEY, MAKE_ZONE);
 
-    it('Should execute labels_list', async () => {
+    it('Should execute scenario-labels_list', async () => {
         mockFetch(`GET https://make.local/api/v2/scenario-labels?teamId=${TEAM_ID}`, listMock);
 
-        const tool = getTool('labels_list');
+        const tool = getTool('scenario-labels_list');
         const result = await tool.execute(make, { teamId: TEAM_ID });
 
         expect(result).toStrictEqual(listMock.labels);
     });
 
-    it('Should execute labels_create', async () => {
+    it('Should execute scenario-labels_create', async () => {
         mockFetch('POST https://make.local/api/v2/scenario-labels', createMock, req => {
             expect(req.body).toStrictEqual({ teamId: TEAM_ID, name: 'critical', colour: 'danger' });
         });
 
-        const tool = getTool('labels_create');
+        const tool = getTool('scenario-labels_create');
         const result = await tool.execute(make, { teamId: TEAM_ID, name: 'critical', colour: 'danger' });
 
         expect(result).toStrictEqual(createMock.label);
     });
 
-    it('Should execute labels_update and separate labelId from the body', async () => {
+    it('Should execute scenario-labels_update and separate labelId from the body', async () => {
         mockFetch(`PATCH https://make.local/api/v2/scenario-labels/${LABEL_ID}`, updateMock, req => {
             expect(req.body).toStrictEqual({ name: 'high-priority', colour: 'warning' });
         });
 
-        const tool = getTool('labels_update');
+        const tool = getTool('scenario-labels_update');
         const result = await tool.execute(make, { labelId: LABEL_ID, name: 'high-priority', colour: 'warning' });
 
         expect(result).toStrictEqual(updateMock.label);
     });
 
-    it('Should execute labels_delete', async () => {
+    it('Should execute scenario-labels_delete', async () => {
         mockFetch(`DELETE https://make.local/api/v2/scenario-labels/${LABEL_ID}`, deleteMock);
 
-        const tool = getTool('labels_delete');
+        const tool = getTool('scenario-labels_delete');
         const result = await tool.execute(make, { labelId: LABEL_ID });
 
         expect(result).toBe('Label has been deleted.');
     });
 
-    it('Should execute labels_assign', async () => {
+    it('Should execute scenario-labels_assign', async () => {
         mockFetch(
             `POST https://make.local/api/v2/scenario-labels/${LABEL_ID}/scenarios/${SCENARIO_ID}`,
             assignMock,
         );
 
-        const tool = getTool('labels_assign');
+        const tool = getTool('scenario-labels_assign');
         const result = await tool.execute(make, { labelId: LABEL_ID, scenarioId: SCENARIO_ID });
 
         expect(result).toBe('Label has been assigned to the scenario.');
     });
 
-    it('Should execute labels_unassign', async () => {
+    it('Should execute scenario-labels_unassign', async () => {
         mockFetch(
             `DELETE https://make.local/api/v2/scenario-labels/${LABEL_ID}/scenarios/${SCENARIO_ID}`,
             assignMock,
         );
 
-        const tool = getTool('labels_unassign');
+        const tool = getTool('scenario-labels_unassign');
         const result = await tool.execute(make, { labelId: LABEL_ID, scenarioId: SCENARIO_ID });
 
         expect(result).toBe('Label has been removed from the scenario.');
     });
 
     it('Should declare the assignment tools as idempotent scenarios:write tools targeting the scenario', () => {
-        for (const name of ['labels_assign', 'labels_unassign']) {
+        for (const name of ['scenario-labels_assign', 'scenario-labels_unassign']) {
             const tool = getTool(name);
             expect(tool.scope).toBe('scenarios:write');
             expect(tool.scopeId).toBe('labelId');
@@ -101,10 +101,10 @@ describe('MCP tools: labels', () => {
         }
     });
 
-    it('Should declare labels_list as a read-only scenarios:read tool scoped by teamId', () => {
-        const tool = getTool('labels_list');
+    it('Should declare scenario-labels_list as a read-only scenarios:read tool scoped by teamId', () => {
+        const tool = getTool('scenario-labels_list');
 
-        expect(tool.category).toBe('labels');
+        expect(tool.category).toBe('scenario-labels');
         expect(tool.scope).toBe('scenarios:read');
         expect(tool.scopeId).toBe('teamId');
         expect(tool.inputSchema.required).toStrictEqual(['teamId']);
@@ -112,18 +112,18 @@ describe('MCP tools: labels', () => {
     });
 
     it('Should declare the label mutation tools as scenarios:write with correct scoping', () => {
-        const create = getTool('labels_create');
+        const create = getTool('scenario-labels_create');
         expect(create.scope).toBe('scenarios:write');
         expect(create.scopeId).toBe('teamId');
         expect(create.inputSchema.required).toStrictEqual(['teamId', 'name', 'colour']);
 
-        const update = getTool('labels_update');
+        const update = getTool('scenario-labels_update');
         expect(update.scope).toBe('scenarios:write');
         expect(update.scopeId).toBe('labelId');
         expect(update.resourceId).toBe('labelId');
         expect(update.inputSchema.required).toStrictEqual(['labelId']);
 
-        const del = getTool('labels_delete');
+        const del = getTool('scenario-labels_delete');
         expect(del.scope).toBe('scenarios:write');
         expect(del.scopeId).toBe('labelId');
         expect(del.resourceId).toBe('labelId');


### PR DESCRIPTION
## Summary
- Renames the scenario-label MCP tools' `category` and name prefix from `labels` to `scenario-labels`, matching the `{category}_{action}` convention every other endpoint follows (and the underlying `scenario-labels.ts` file/`ScenarioLabels` class).
- Addresses review feedback on BAR-3814: bare `labels` risked future naming collisions and was inconsistent with the rest of the tool catalog.

### Changed tools
- `labels_list` → `scenario-labels_list`
- `labels_create` → `scenario-labels_create`
- `labels_update` → `scenario-labels_update`
- `labels_delete` → `scenario-labels_delete`
- `labels_assign` → `scenario-labels_assign`
- `labels_unassign` → `scenario-labels_unassign`

No SDK method, class, or mock fixture names changed — this is scoped to the MCP tool layer (name/category) plus one doc reference in `scenarios.tools.ts` and the README tool-category list. Confirmed `make-mcp-server-host` has no dependency on the old tool names.

## Test plan
- [x] `npm run lint`
- [x] typecheck
- [x] `test/scenario-labels-tools.spec.ts` passes with updated tool names