### PR TITLE
chore: bump version to 1.6.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.13",
+    "version": "1.6.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/sdk",
-            "version": "1.6.13",
+            "version": "1.6.14",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/sdk",
-    "version": "1.6.13",
+    "version": "1.6.14",
     "description": "Make TypeScript SDK",
     "license": "MIT",
     "author": "Make",


### PR DESCRIPTION
## Summary
- Bump version to 1.6.14 for release.

Changes since v1.6.13:
- [fix(scenarios): stop wiping a scenario's interface on every update (WM-4599)](https://github.com/integromat/make-typescript-sdk/commit/0662878)